### PR TITLE
Support package extras when installing the local package

### DIFF
--- a/src/nox_poetry/core.py
+++ b/src/nox_poetry/core.py
@@ -1,8 +1,11 @@
 """Core functions."""
 import hashlib
+import re
 from pathlib import Path
 from typing import Any
 from typing import Iterable
+from typing import Optional
+from typing import Tuple
 
 from nox.sessions import Session
 
@@ -82,6 +85,17 @@ def build_package(session: Session, *, distribution_format: DistributionFormat) 
     return url
 
 
+_EXTRAS_PATTERN = re.compile(r"^(.+)(\[[^\]]+\])$")
+
+
+def _split_extras(arg: str) -> Tuple[str, Optional[str]]:
+    # From ``pip._internal.req.constructors._strip_extras``
+    match = _EXTRAS_PATTERN.match(arg)
+    if match:
+        return match.group(1), match.group(2)
+    return arg, None
+
+
 def install(session: Session, *args: str, **kwargs: Any) -> None:
     """Install packages into a Nox session using Poetry.
 
@@ -116,9 +130,23 @@ def install(session: Session, *args: str, **kwargs: Any) -> None:
         kwargs: Keyword-arguments for ``session.install``. These are the same
             as those for `nox.sessions.Session.run`_.
     """
-    if "." in args:
+    args_extras = [_split_extras(arg) for arg in args]
+
+    if "." in [arg for arg, _ in args_extras]:
         package = build_package(session, distribution_format=DistributionFormat.WHEEL)
-        args = tuple(package if arg == "." else arg for arg in args)
+
+        def rewrite(arg: str, extras: Optional[str]) -> str:
+            if arg != ".":
+                return arg if extras is None else arg + extras
+
+            if extras is None:
+                return package
+
+            name = Poetry(session).config.name
+            return f"{name}{extras} @ {package}"
+
+        args = tuple(rewrite(arg, extras) for arg, extras in args_extras)
+
         session.run("pip", "uninstall", "--yes", package, silent=True)
 
     requirements = export_requirements(session)

--- a/src/nox_poetry/core.py
+++ b/src/nox_poetry/core.py
@@ -2,6 +2,7 @@
 import hashlib
 from pathlib import Path
 from typing import Any
+from typing import Iterable
 
 from nox.sessions import Session
 
@@ -128,6 +129,7 @@ def installroot(
     session: Session,
     *,
     distribution_format: DistributionFormat,
+    extras: Iterable[str] = (),
 ) -> None:
     """Install the root package into a Nox session using Poetry.
 
@@ -142,11 +144,19 @@ def installroot(
     Args:
         session: The Session object.
         distribution_format: The distribution format, either wheel or sdist.
+        extras: Extras to install for the package.
     """
     package = build_package(session, distribution_format=distribution_format)
     requirements = export_requirements(session)
 
     session.run("pip", "uninstall", "--yes", package, silent=True)
+
+    suffix = ",".join(extras)
+    if suffix.strip():
+        suffix = suffix.join("[]")
+        name = Poetry(session).config.name
+        package = f"{name}{suffix} @ {package}"
+
     Session_install(session, f"--constraint={requirements}", package)
 
 

--- a/src/nox_poetry/poetry.py
+++ b/src/nox_poetry/poetry.py
@@ -1,6 +1,7 @@
 """Poetry interface."""
 from enum import Enum
 from pathlib import Path
+from typing import List
 from typing import Optional
 
 import tomlkit
@@ -30,6 +31,15 @@ class Config:
         name = self._config["name"]
         assert isinstance(name, str)  # noqa: S101
         return name
+
+    @property
+    def extras(self) -> List[str]:
+        """Return the package extras."""
+        extras = self._config.get("extras", {})
+        assert isinstance(extras, dict) and all(  # noqa: S101
+            isinstance(extra, str) for extra in extras
+        )
+        return list(extras)
 
 
 class Poetry:

--- a/src/nox_poetry/poetry.py
+++ b/src/nox_poetry/poetry.py
@@ -73,6 +73,7 @@ class Poetry:
             "--format=requirements.txt",
             f"--output={path}",
             "--dev",
+            *[f"--extras={extra}" for extra in self.config.extras],
             external=True,
         )
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -66,12 +66,17 @@ class Project:
     @property
     def dependencies(self) -> List[Package]:
         """Return the package dependencies."""
-        dependencies: List[str] = list(self._get_config("dependencies"))
-        return [
-            self.get_dependency(package)
-            for package in dependencies
-            if package != "python"
+        table = self._get_config("dependencies")
+        dependencies: List[str] = [
+            package
+            for package, info in table.items()
+            if not (
+                package == "python"
+                or isinstance(info, dict)
+                and info.get("optional", None)
+            )
         ]
+        return [self.get_dependency(package) for package in dependencies]
 
     @property
     def development_dependencies(self) -> List[Package]:

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -1,5 +1,6 @@
 """Functional tests."""
 import nox.sessions
+import pytest
 from tests.functional.conftest import ListPackages
 from tests.functional.conftest import Project
 from tests.functional.conftest import RunNoxWithNoxfile
@@ -67,6 +68,33 @@ def test_installroot_wheel(
     assert set(expected) == set(packages)
 
 
+@pytest.mark.xfail(reason="not implemented")
+def test_installroot_wheel_with_extras(
+    project: Project,
+    run_nox_with_noxfile: RunNoxWithNoxfile,
+    list_packages: ListPackages,
+) -> None:
+    """It installs the extra."""
+
+    @nox.session
+    def test(session: nox.sessions.Session) -> None:
+        """Install the local package."""
+        nox_poetry.installroot(
+            session, distribution_format=nox_poetry.WHEEL, extras=["pygments"]
+        )
+
+    run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry])
+
+    expected = [
+        project.package,
+        *project.dependencies,
+        project.get_dependency("pygments"),
+    ]
+    packages = list_packages(test)
+
+    assert set(expected) == set(packages)
+
+
 def test_installroot_sdist(
     project: Project,
     run_nox_with_noxfile: RunNoxWithNoxfile,
@@ -82,6 +110,33 @@ def test_installroot_sdist(
     run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry])
 
     expected = [project.package, *project.dependencies]
+    packages = list_packages(test)
+
+    assert set(expected) == set(packages)
+
+
+@pytest.mark.xfail(reason="not implemented")
+def test_installroot_sdist_with_extras(
+    project: Project,
+    run_nox_with_noxfile: RunNoxWithNoxfile,
+    list_packages: ListPackages,
+) -> None:
+    """It installs the extra."""
+
+    @nox.session
+    def test(session: nox.sessions.Session) -> None:
+        """Install the local package."""
+        nox_poetry.installroot(
+            session, distribution_format=nox_poetry.SDIST, extras=["pygments"]
+        )
+
+    run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry])
+
+    expected = [
+        project.package,
+        *project.dependencies,
+        project.get_dependency("pygments"),
+    ]
     packages = list_packages(test)
 
     assert set(expected) == set(packages)

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -13,7 +13,7 @@ def test_install_local_using_patch(
     run_nox_with_noxfile: RunNoxWithNoxfile,
     list_packages: ListPackages,
 ) -> None:
-    """Invoking session.install(".") installs the local package."""
+    """It installs the local package."""
 
     @nox.session
     def test(session: nox.sessions.Session) -> None:
@@ -23,6 +23,31 @@ def test_install_local_using_patch(
     run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry.patch])
 
     expected = [project.package, *project.dependencies]
+    packages = list_packages(test)
+
+    assert set(expected) == set(packages)
+
+
+@pytest.mark.xfail(reason="not implemented")
+def test_install_local_using_patch_with_extras(
+    project: Project,
+    run_nox_with_noxfile: RunNoxWithNoxfile,
+    list_packages: ListPackages,
+) -> None:
+    """It installs the extra."""
+
+    @nox.session
+    def test(session: nox.sessions.Session) -> None:
+        """Install the local package."""
+        session.install(".[pygments]")
+
+    run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry.patch])
+
+    expected = [
+        project.package,
+        *project.dependencies,
+        project.get_dependency("pygments"),
+    ]
     packages = list_packages(test)
 
     assert set(expected) == set(packages)
@@ -43,6 +68,31 @@ def test_install_local_wheel(
     run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry])
 
     expected = [project.package, *project.dependencies]
+    packages = list_packages(test)
+
+    assert set(expected) == set(packages)
+
+
+@pytest.mark.xfail(reason="not implemented")
+def test_install_local_wheel_with_extras(
+    project: Project,
+    run_nox_with_noxfile: RunNoxWithNoxfile,
+    list_packages: ListPackages,
+) -> None:
+    """It installs the extra."""
+
+    @nox.session
+    def test(session: nox.sessions.Session) -> None:
+        """Install the local package."""
+        nox_poetry.install(session, ".[pygments]")
+
+    run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry])
+
+    expected = [
+        project.package,
+        *project.dependencies,
+        project.get_dependency("pygments"),
+    ]
     packages = list_packages(test)
 
     assert set(expected) == set(packages)

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -1,6 +1,5 @@
 """Functional tests."""
 import nox.sessions
-import pytest
 from tests.functional.conftest import ListPackages
 from tests.functional.conftest import Project
 from tests.functional.conftest import RunNoxWithNoxfile
@@ -28,7 +27,6 @@ def test_install_local_using_patch(
     assert set(expected) == set(packages)
 
 
-@pytest.mark.xfail(reason="not implemented")
 def test_install_local_using_patch_with_extras(
     project: Project,
     run_nox_with_noxfile: RunNoxWithNoxfile,
@@ -73,7 +71,6 @@ def test_install_local_wheel(
     assert set(expected) == set(packages)
 
 
-@pytest.mark.xfail(reason="not implemented")
 def test_install_local_wheel_with_extras(
     project: Project,
     run_nox_with_noxfile: RunNoxWithNoxfile,
@@ -118,7 +115,6 @@ def test_installroot_wheel(
     assert set(expected) == set(packages)
 
 
-@pytest.mark.xfail(reason="not implemented")
 def test_installroot_wheel_with_extras(
     project: Project,
     run_nox_with_noxfile: RunNoxWithNoxfile,
@@ -165,7 +161,6 @@ def test_installroot_sdist(
     assert set(expected) == set(packages)
 
 
-@pytest.mark.xfail(reason="not implemented")
 def test_installroot_sdist_with_extras(
     project: Project,
     run_nox_with_noxfile: RunNoxWithNoxfile,

--- a/tests/functional/test_functional/example/poetry.lock
+++ b/tests/functional/test_functional/example/poetry.lock
@@ -22,10 +22,18 @@ category = "dev"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
+[[package]]
+name = "pygments"
+version = "2.7.1"
+description = "Pygments is a syntax highlighting package written in Python."
+category = "main"
+optional = true
+python-versions = ">=3.5"
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "22284e63f0c4ea15ae0dbf8679100d32c868b2be6ff62c4033fdf1f624c48c83"
+content-hash = "f5547369ad3ec6982e639f14762f208d11df24ddb8e43c51a0af88d9fb2f6198"
 
 [metadata.files]
 first = [
@@ -39,4 +47,8 @@ pycodestyle = [
 pyflakes = [
     {file = "pyflakes-2.1.1-py2.py3-none-any.whl", hash = "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0"},
     {file = "pyflakes-2.1.1.tar.gz", hash = "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"},
+]
+pygments = [
+    {file = "Pygments-2.7.1-py3-none-any.whl", hash = "sha256:307543fe65c0947b126e83dd5a61bd8acbd84abec11f43caebaf5534cbc17998"},
+    {file = "Pygments-2.7.1.tar.gz", hash = "sha256:926c3f319eda178d1bd90851e4317e6d8cdb5e292a3386aac9bd75eca29cf9c7"},
 ]

--- a/tests/functional/test_functional/example/poetry.lock
+++ b/tests/functional/test_functional/example/poetry.lock
@@ -30,10 +30,13 @@ category = "main"
 optional = true
 python-versions = ">=3.5"
 
+[extras]
+pygments = ["Pygments"]
+
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "f5547369ad3ec6982e639f14762f208d11df24ddb8e43c51a0af88d9fb2f6198"
+content-hash = "65a484a1a7ee49c3993d8103bddeeef3c94fc4fb6c3f3805d58941333e49e82a"
 
 [metadata.files]
 first = [

--- a/tests/functional/test_functional/example/pyproject.toml
+++ b/tests/functional/test_functional/example/pyproject.toml
@@ -13,6 +13,9 @@ Pygments = {version = "^2.7.1", optional = true}
 pyflakes = "^2.1.1"
 pycodestyle = "^2.5.0"
 
+[tool.poetry.extras]
+pygments = ["pygments"]
+
 [build-system]
 requires = ["poetry-core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"

--- a/tests/functional/test_functional/example/pyproject.toml
+++ b/tests/functional/test_functional/example/pyproject.toml
@@ -7,6 +7,7 @@ authors = ["Your Name <your.name@example.com>"]
 [tool.poetry.dependencies]
 python = "^3.6.1"
 first = "^2.0.0"
+Pygments = {version = "^2.7.1", optional = true}
 
 [tool.poetry.dev-dependencies]
 pyflakes = "^2.1.1"

--- a/tests/unit/test_nox_poetry.py
+++ b/tests/unit/test_nox_poetry.py
@@ -15,6 +15,9 @@ from nox_poetry.poetry import Poetry
         ["."],
         ["pyflakes"],
         [".", "pyflakes"],
+        [".[noodles]"],
+        ["pyflakes[honey]"],
+        [".[spicy, noodles]", "pyflakes[honey]"],
     ],
 )
 def test_install(session: Session, args: Iterable[str]) -> None:

--- a/tests/unit/test_nox_poetry.py
+++ b/tests/unit/test_nox_poetry.py
@@ -1,4 +1,6 @@
 """Unit tests."""
+from typing import Iterable
+
 import pytest
 from nox.sessions import Session
 
@@ -7,14 +9,17 @@ from nox_poetry.poetry import DistributionFormat
 from nox_poetry.poetry import Poetry
 
 
-def test_install_package(session: Session) -> None:
-    """It installs the package."""
-    nox_poetry.install(session, ".")
-
-
-def test_install_dependency(session: Session) -> None:
-    """It installs the dependency."""
-    nox_poetry.install(session, "pip")
+@pytest.mark.parametrize(
+    "args",
+    [
+        ["."],
+        ["pyflakes"],
+        [".", "pyflakes"],
+    ],
+)
+def test_install(session: Session, args: Iterable[str]) -> None:
+    """It installs the specified packages."""
+    nox_poetry.install(session, *args)
 
 
 @pytest.mark.parametrize("distribution_format", [nox_poetry.WHEEL, nox_poetry.SDIST])

--- a/tests/unit/test_nox_poetry.py
+++ b/tests/unit/test_nox_poetry.py
@@ -28,6 +28,18 @@ def test_installroot(session: Session, distribution_format: DistributionFormat) 
     nox_poetry.installroot(session, distribution_format=distribution_format)
 
 
+@pytest.mark.xfail(reason="not implemented")
+@pytest.mark.parametrize("distribution_format", [nox_poetry.WHEEL, nox_poetry.SDIST])
+@pytest.mark.parametrize("extras", [[], ["noodles"], ["spicy", "noodles"]])
+def test_installroot_with_extras(
+    session: Session, distribution_format: DistributionFormat, extras: Iterable[str]
+) -> None:
+    """It installs the package with extras."""
+    nox_poetry.installroot(
+        session, distribution_format=distribution_format, extras=extras
+    )
+
+
 def test_export_requirements(session: Session) -> None:
     """It exports the requirements."""
     nox_poetry.export_requirements(session).touch()

--- a/tests/unit/test_nox_poetry.py
+++ b/tests/unit/test_nox_poetry.py
@@ -31,7 +31,6 @@ def test_installroot(session: Session, distribution_format: DistributionFormat) 
     nox_poetry.installroot(session, distribution_format=distribution_format)
 
 
-@pytest.mark.xfail(reason="not implemented")
 @pytest.mark.parametrize("distribution_format", [nox_poetry.WHEEL, nox_poetry.SDIST])
 @pytest.mark.parametrize("extras", [[], ["noodles"], ["spicy", "noodles"]])
 def test_installroot_with_extras(


### PR DESCRIPTION
- Translate `".[...]"` to `"name[...] @ url"` ([PEP 508]).
- Add an optional parameter `extras` to the `installroot` function.

Currently, an argument like `".[extra]"` is passed unmodified to pip, so the installation fails due to missing hashes.

Closes #146

[pep 508]: https://www.python.org/dev/peps/pep-0508/