### PR TITLE
Add function to install the local package

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,9 +95,8 @@ installs the wheel as well as the ``pytest`` package, and
 invokes ``pytest`` to run the test suite against the installation.
 
 If you prefer a more explicit approach,
-you can also invoke ``nox_poetry.install`` instead of ``session.install``.
-Pass ``nox_poetry.WHEEL`` or ``nox_poetry.SDIST`` to build and install the local package
-using the specified distribution format.
+you can invoke ``nox_poetry.install`` and ``nox_poetry.installroot`` instead of ``session.install``.
+Use the ``nox_poetry.WHEEL`` or ``nox_poetry.SDIST`` constants to specify the distribution format for the local package.
 
 Here is that same example using the more explicit approach:
 
@@ -111,7 +110,8 @@ Here is that same example using the more explicit approach:
    @nox.session
    def tests(session: Session) -> None:
        """Run the test suite."""
-       nox_poetry.install(session, nox_poetry.WHEEL)
+       nox_poetry.installroot(session, distribution_format=nox_poetry.WHEEL)
+       #nox_poetry.install(session, ".")  # this is equivalent to the statement above
        nox_poetry.install(session, "pytest")
        session.run("pytest")
 

--- a/docs/reference.rst
+++ b/docs/reference.rst
@@ -13,6 +13,7 @@ Functions
 .........
 
 .. autofunction:: install
+.. autofunction:: installroot
 .. autofunction:: build_package
 .. autofunction:: export_requirements
 .. autofunction:: nox_poetry.core.patch

--- a/src/nox_poetry/__init__.py
+++ b/src/nox_poetry/__init__.py
@@ -19,6 +19,7 @@ Two constants are defined to specify the format for distribution archives:
 from nox_poetry.core import build_package
 from nox_poetry.core import export_requirements
 from nox_poetry.core import install
+from nox_poetry.core import installroot
 from nox_poetry.poetry import DistributionFormat
 
 
@@ -32,6 +33,7 @@ __all__ = [
     "build_package",
     "export_requirements",
     "install",
+    "installroot",
     "SDIST",
     "WHEEL",
 ]

--- a/src/nox_poetry/core.py
+++ b/src/nox_poetry/core.py
@@ -143,6 +143,32 @@ def install(
     )
 
 
+def installroot(
+    session: Session,
+    *,
+    distribution_format: DistributionFormat,
+) -> None:
+    """Install the root package into a Nox session using Poetry.
+
+    This function installs the package located in the current directory into the
+    session's virtual environment.
+
+    A constraints file is generated for the package dependencies using
+    :func:`export_requirements`, and passed to ``pip install`` via its
+    ``--constraint`` option. This ensures that core dependencies are installed
+    using the versions specified in Poetry's lock file.
+
+    Args:
+        session: The Session object.
+        distribution_format: The distribution format, either wheel or sdist.
+    """
+    package = build_package(session, distribution_format=distribution_format)
+    requirements = export_requirements(session)
+
+    session.run("pip", "uninstall", "--yes", package, silent=True)
+    Session_install(session, f"--constraint={requirements}", package)
+
+
 def patch(
     *, distribution_format: DistributionFormat = DistributionFormat.WHEEL
 ) -> None:

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -67,6 +67,46 @@ def test_install_local_sdist(
     assert set(expected) == set(packages)
 
 
+def test_installroot_wheel(
+    project: Project,
+    run_nox_with_noxfile: RunNoxWithNoxfile,
+    list_packages: ListPackages,
+) -> None:
+    """It builds and installs a wheel from the local package."""
+
+    @nox.session
+    def test(session: nox.sessions.Session) -> None:
+        """Install the local package."""
+        nox_poetry.installroot(session, distribution_format=nox_poetry.WHEEL)
+
+    run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry])
+
+    expected = [project.package, *project.dependencies]
+    packages = list_packages(test)
+
+    assert set(expected) == set(packages)
+
+
+def test_installroot_sdist(
+    project: Project,
+    run_nox_with_noxfile: RunNoxWithNoxfile,
+    list_packages: ListPackages,
+) -> None:
+    """It builds and installs an sdist from the local package."""
+
+    @nox.session
+    def test(session: nox.sessions.Session) -> None:
+        """Install the local package."""
+        nox_poetry.installroot(session, distribution_format=nox_poetry.SDIST)
+
+    run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry])
+
+    expected = [project.package, *project.dependencies]
+    packages = list_packages(test)
+
+    assert set(expected) == set(packages)
+
+
 def test_install_dependency_using_patch(
     project: Project,
     run_nox_with_noxfile: RunNoxWithNoxfile,

--- a/tests/unit/test_nox_poetry.py
+++ b/tests/unit/test_nox_poetry.py
@@ -12,6 +12,12 @@ def test_install(session: Session, distribution_format: DistributionFormat) -> N
     nox_poetry.install(session, distribution_format, "pip")
 
 
+@pytest.mark.parametrize("distribution_format", [nox_poetry.WHEEL, nox_poetry.SDIST])
+def test_installroot(session: Session, distribution_format: DistributionFormat) -> None:
+    """It installs the package."""
+    nox_poetry.installroot(session, distribution_format=distribution_format)
+
+
 def test_export_requirements(session: Session) -> None:
     """It exports the requirements."""
     nox_poetry.export_requirements(session).touch()


### PR DESCRIPTION
Add a function `installroot(session, distribution_format=WHEEL|SDIST)` which builds and installs the local package.

**Rationale**

The `install` function will switch to use the same signature as `session.install`. This will make it impossible to install via sdist using it.

**Rejected Ideas**

```python
package = build_package(session, distribution_format=SDIST)
install(session, package)
```

This is a pitfall, because we also need to uninstall the package if the virtualenv is being reused.