### PR TITLE
Use "." in install() instead of DistributionFormat

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -95,10 +95,10 @@ installs the wheel as well as the ``pytest`` package, and
 invokes ``pytest`` to run the test suite against the installation.
 
 If you prefer a more explicit approach,
-you can invoke ``nox_poetry.install`` and ``nox_poetry.installroot`` instead of ``session.install``.
+invoke ``nox_poetry.install`` and ``nox_poetry.installroot`` instead of ``session.install``.
 Use the ``nox_poetry.WHEEL`` or ``nox_poetry.SDIST`` constants to specify the distribution format for the local package.
 
-Here is that same example using the more explicit approach:
+Here is the example above using the more explicit approach:
 
 .. code:: python
 

--- a/src/nox_poetry/core.py
+++ b/src/nox_poetry/core.py
@@ -2,8 +2,6 @@
 import hashlib
 from pathlib import Path
 from typing import Any
-from typing import List
-from typing import Union
 
 from nox.sessions import Session
 
@@ -173,11 +171,4 @@ def patch(
         distribution_format: The distribution format to use when the ``"."``
             argument is encountered in calls to ``session.install``.
     """
-
-    def patched_install(self: Session, *args: str, **kwargs: Any) -> None:
-        newargs: List[Union[DistributionFormat, str]] = [
-            distribution_format if arg == "." else arg for arg in args
-        ]
-        install(self, *newargs, **kwargs)
-
-    Session.install = patched_install  # type: ignore[assignment]
+    Session.install = install  # type: ignore[assignment]

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -37,27 +37,7 @@ def test_install_local_wheel(
     @nox.session
     def test(session: nox.sessions.Session) -> None:
         """Install the local package."""
-        nox_poetry.install(session, nox_poetry.WHEEL)
-
-    run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry])
-
-    expected = [project.package, *project.dependencies]
-    packages = list_packages(test)
-
-    assert set(expected) == set(packages)
-
-
-def test_install_local_sdist(
-    project: Project,
-    run_nox_with_noxfile: RunNoxWithNoxfile,
-    list_packages: ListPackages,
-) -> None:
-    """It builds and installs an sdist from the local package."""
-
-    @nox.session
-    def test(session: nox.sessions.Session) -> None:
-        """Install the local package."""
-        nox_poetry.install(session, nox_poetry.SDIST)
+        nox_poetry.install(session, ".")
 
     run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry])
 
@@ -181,7 +161,7 @@ def test_install_local_wheel_and_dependency_without_patch(
     @nox.session
     def test(session: nox.sessions.Session) -> None:
         """Install the dependency."""
-        nox_poetry.install(session, nox_poetry.WHEEL, "pycodestyle")
+        nox_poetry.install(session, ".", "pycodestyle")
 
     run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry])
 

--- a/tests/unit/test_nox_poetry.py
+++ b/tests/unit/test_nox_poetry.py
@@ -6,10 +6,14 @@ import nox_poetry
 from nox_poetry.poetry import DistributionFormat
 
 
-@pytest.mark.parametrize("distribution_format", [nox_poetry.WHEEL, nox_poetry.SDIST])
-def test_install(session: Session, distribution_format: DistributionFormat) -> None:
-    """It installs the dependencies."""
-    nox_poetry.install(session, distribution_format, "pip")
+def test_install_package(session: Session) -> None:
+    """It installs the package."""
+    nox_poetry.install(session, ".")
+
+
+def test_install_dependency(session: Session) -> None:
+    """It installs the dependency."""
+    nox_poetry.install(session, "pip")
 
 
 @pytest.mark.parametrize("distribution_format", [nox_poetry.WHEEL, nox_poetry.SDIST])


### PR DESCRIPTION
Use the same type signature for `install` that `nox.Session.install` uses.

The function no longer accepts `DistributionFormat` values in its arguments list. Use `installroot` instead.

**Rationale**

Besides the advantages of symmetry, this will allow us to handle extras for the local package. The enum-based interface does not allow expressing extras. By moving the translation logic from the patched `Session.install` function to `install`, we are able to pass arguments like `".[extra]"`. Interpreting extras as appropriate is left for a follow-up.
