### PR TITLE
Read package name from pyproject.toml

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1250,7 +1250,7 @@ python-versions = "*"
 name = "tomlkit"
 version = "0.7.0"
 description = "Style preserving TOML library"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*, !=3.4.*"
 
@@ -1364,7 +1364,7 @@ testing = ["pytest (>=3.5,<3.7.3 || >3.7.3)", "pytest-checkdocs (>=1.2.3)", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "ef1161ba0bc175c682d3a7131508c7347f6e806847344e88fccfdf9a251716d9"
+content-hash = "d58c3b678b5e3f5a392cfcd6f5362743b6e2cc5bbe6a78f246ce3d25185ae9b0"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -22,6 +22,7 @@ Changelog = "https://github.com/cjolowicz/nox-poetry/releases"
 [tool.poetry.dependencies]
 python = "^3.6.1"
 nox = "^2020.5.24"
+tomlkit = "^0.7.0"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.1.2"

--- a/src/nox_poetry/core.py
+++ b/src/nox_poetry/core.py
@@ -76,8 +76,7 @@ def build_package(session: Session, *, distribution_format: DistributionFormat) 
     url = f"file://{wheel.resolve().as_posix()}#sha256={digest}"
 
     if distribution_format is DistributionFormat.SDIST:
-        name = poetry.version().split()[0]
-        url += f"&egg={name}"
+        url += f"&egg={poetry.config.name}"
 
     return url
 

--- a/src/nox_poetry/poetry.py
+++ b/src/nox_poetry/poetry.py
@@ -1,6 +1,7 @@
 """Poetry interface."""
 from enum import Enum
 from pathlib import Path
+from typing import Optional
 
 import tomlkit
 from nox.sessions import Session
@@ -41,6 +42,14 @@ class Poetry:
     def __init__(self, session: Session) -> None:
         """Initialize."""
         self.session = session
+        self._config: Optional[Config] = None
+
+    @property
+    def config(self) -> Config:
+        """Return the package configuration."""
+        if self._config is None:
+            self._config = Config(Path.cwd())
+        return self._config
 
     def export(self, path: Path) -> None:
         """Export the lock file to requirements format.

--- a/src/nox_poetry/poetry.py
+++ b/src/nox_poetry/poetry.py
@@ -97,19 +97,3 @@ class Poetry:
         )
         assert isinstance(output, str)  # noqa: S101
         return output.split()[-1]
-
-    def version(self) -> str:
-        """Return the package name and version.
-
-        Returns:
-            The package name and version.
-        """
-        output = self.session.run(
-            "poetry",
-            "version",
-            external=True,
-            silent=True,
-            stderr=None,
-        )
-        assert isinstance(output, str)  # noqa: S101
-        return output.strip()

--- a/src/nox_poetry/poetry.py
+++ b/src/nox_poetry/poetry.py
@@ -2,6 +2,7 @@
 from enum import Enum
 from pathlib import Path
 
+import tomlkit
 from nox.sessions import Session
 
 
@@ -10,6 +11,24 @@ class DistributionFormat(Enum):
 
     WHEEL = "wheel"
     SDIST = "sdist"
+
+
+class Config:
+    """Poetry configuration."""
+
+    def __init__(self, project: Path) -> None:
+        """Initialize."""
+        path = project / "pyproject.toml"
+        text = path.read_text()
+        data = tomlkit.parse(text)
+        self._config = data["tool"]["poetry"]
+
+    @property
+    def name(self) -> str:
+        """Return the package name."""
+        name = self._config["name"]
+        assert isinstance(name, str)  # noqa: S101
+        return name
 
 
 class Poetry:

--- a/tests/unit/test_nox_poetry.py
+++ b/tests/unit/test_nox_poetry.py
@@ -4,6 +4,7 @@ from nox.sessions import Session
 
 import nox_poetry
 from nox_poetry.poetry import DistributionFormat
+from nox_poetry.poetry import Poetry
 
 
 def test_install_package(session: Session) -> None:
@@ -33,3 +34,10 @@ def test_patch(session: Session) -> None:
     import nox_poetry.patch  # noqa: F401
 
     Session.install(session, ".")
+
+
+def test_poetry_config(session: Session) -> None:
+    """It caches the configuration when accessed multiple times."""
+    poetry = Poetry(session)
+    poetry.config
+    assert poetry.config.name == "nox-poetry"


### PR DESCRIPTION
- Add `Poetry.config.name` property to provide access to the package name as defined in `pyproject.toml`.
- Use this property to construct the egg fragment for sdist file URLs.

**Rationale:**

- Avoid spawning a subprocess running `poetry version` to determine the name.
- Avoid the need to parse Poetry output meant for human consumption.
- We will need to parse pyproject.toml anyway for extras support.

Note that `poetry version` canonicalizes the package name. We don't bother here, because `pip uninstall` will do so anyway.