### PR TITLE
Decode pyproject.toml as UTF-8 regardless of system locale

### DIFF
--- a/src/nox_poetry/poetry.py
+++ b/src/nox_poetry/poetry.py
@@ -21,7 +21,7 @@ class Config:
     def __init__(self, project: Path) -> None:
         """Initialize."""
         path = project / "pyproject.toml"
-        text = path.read_bytes()
+        text = path.read_text(encoding="utf-8")
         data = tomlkit.parse(text)
         self._config = data["tool"]["poetry"]
 

--- a/src/nox_poetry/poetry.py
+++ b/src/nox_poetry/poetry.py
@@ -21,7 +21,7 @@ class Config:
     def __init__(self, project: Path) -> None:
         """Initialize."""
         path = project / "pyproject.toml"
-        text = path.read_text()
+        text = path.read_bytes()
         data = tomlkit.parse(text)
         self._config = data["tool"]["poetry"]
 


### PR DESCRIPTION
- Just passes binary to tomlkit. The only way to work on Windows to parse .toml files with special characters.

Closes #213 