### PR TITLE
Add test for non-ASCII characters in pyproject.toml

### DIFF
--- a/tests/unit/test_poetry.py
+++ b/tests/unit/test_poetry.py
@@ -1,0 +1,18 @@
+"""Unit tests for the poetry module."""
+from pathlib import Path
+
+from nox_poetry import poetry
+
+
+def test_config_non_ascii(tmp_path: Path) -> None:
+    """It decodes non-ASCII characters in pyproject.toml."""
+    text = """\
+[tool.poetry]
+name = "África"
+"""
+
+    path = tmp_path / "pyproject.toml"
+    path.write_text(text, encoding="utf-8")
+
+    config = poetry.Config(path.parent)
+    assert config.name == "África"


### PR DESCRIPTION
poetry.Config incorrectly used Path.read_text without specifying UTF-8 as the
encoding. On systems with a non-UTF-8 locale, this can lead to decoding errors
because the preferred encoding on the system would be used to decode the
contents of pyproject.toml. This can result in garbled configuration values or
a UnicodeDecodeError exception. For example, the character `Á` will fail to
decode on Windows systems with CP-1252 as the preferred locale encoding.

See #233