### PR TITLE
Forward additional arguments to parametrized sessions

### DIFF
--- a/src/nox_poetry/sessions.py
+++ b/src/nox_poetry/sessions.py
@@ -37,9 +37,9 @@ def session(*args: Any, **kwargs: Any) -> Any:
     [function] = args
 
     @functools.wraps(function)
-    def wrapper(session: nox.Session) -> None:
+    def wrapper(session: nox.Session, *_args, **_kwargs) -> None:
         proxy = Session(session)
-        function(proxy)
+        function(proxy, *_args, **_kwargs)
 
     return nox.session(wrapper, **kwargs)  # type: ignore[call-overload]
 

--- a/src/nox_poetry/sessions.pyi
+++ b/src/nox_poetry/sessions.pyi
@@ -62,11 +62,10 @@ class Session:
     def error(self, *args: Any) -> NoReturn: ...
     def skip(self, *args: Any) -> NoReturn: ...
 
-SessionFunction = Callable[[Session], None]
-NoxSessionFunction = Callable[[nox.Session], None]
-SessionDecorator = Callable[[SessionFunction], NoxSessionFunction]
+SessionFunction = Callable[..., None]
+SessionDecorator = Callable[[SessionFunction], SessionFunction]
 @overload
-def session(__func: SessionFunction) -> NoxSessionFunction: ...
+def session(__func: SessionFunction) -> SessionFunction: ...
 @overload
 def session(
     __func: None = ...,

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -361,3 +361,17 @@ def test_session_install_local_wheel_and_dependency(
     packages = list_packages(test)
 
     assert set(expected) == set(packages)
+
+
+def test_session_parametrize(
+    project: Project,
+    run_nox_with_noxfile: RunNoxWithNoxfile,
+) -> None:
+    """It forwards parameters to sessions."""
+
+    @nox_poetry.session
+    @nox.parametrize("n", [1, 2])
+    def test(session: nox_poetry.Session, n: int) -> None:
+        """Do nothing."""
+
+    run_nox_with_noxfile([test], [nox, nox_poetry])

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -28,6 +28,16 @@ def iter_sessions() -> IterSessions:
     return _iter_sessions
 
 
+def test_register(iter_sessions: IterSessions) -> None:
+    """It registers the session function."""
+
+    @nox_poetry.session
+    def tests(session: nox_poetry.Session) -> None:
+        pass
+
+    assert "tests" in iter_sessions()
+
+
 def test_name(iter_sessions: IterSessions) -> None:
     """It registers the session function under the given name."""
 

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -28,8 +28,8 @@ def iter_sessions() -> IterSessions:
     return _iter_sessions
 
 
-def test_kwargs(iter_sessions: IterSessions) -> None:
-    """It registers the session function."""
+def test_name(iter_sessions: IterSessions) -> None:
+    """It registers the session function under the given name."""
 
     @nox_poetry.session(name="tests-renamed")
     def tests(session: nox_poetry.Session) -> None:

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -88,6 +88,24 @@ def test_wrapper(session: nox.Session) -> None:
     assert proxy._session is session
 
 
+def test_wrapper_parametrize(session: nox.Session) -> None:
+    """It forwards parameters to the session function."""
+    calls = []
+
+    @nox_poetry.session
+    @nox.parametrize("number", [1, 2])
+    def tests(proxy: nox_poetry.Session, number: int) -> None:
+        calls.append((proxy, number))
+
+    tests(session, 1)  # type: ignore[no-untyped-call]
+    tests(session, 2)  # type: ignore[no-untyped-call]
+
+    proxies, numbers = zip(*calls)
+
+    assert all(proxy._session is session for proxy in proxies)
+    assert numbers == (1, 2)
+
+
 @pytest.fixture
 def proxy(session: nox.Session) -> nox_poetry.Session:
     """Fixture for session proxy."""

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -28,14 +28,14 @@ def iter_sessions() -> IterSessions:
     return _iter_sessions
 
 
-def test_kwargs() -> None:
+def test_kwargs(iter_sessions: IterSessions) -> None:
     """It registers the session function."""
 
     @nox_poetry.session(name="tests-renamed")
     def tests(session: nox_poetry.Session) -> None:
         pass
 
-    assert "tests-renamed" in nox.registry.get()
+    assert "tests-renamed" in iter_sessions()
 
 
 def test_wrapper(session: nox.Session) -> None:

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -1,8 +1,31 @@
 """Unit tests for the sessions module."""
+from typing import Callable
+from typing import Iterator
+
+import nox._options
+import nox.manifest
 import nox.registry
 import pytest
 
 import nox_poetry
+
+
+IterSessions = Callable[[], Iterator[str]]
+
+
+@pytest.fixture
+def iter_sessions() -> IterSessions:
+    """List the registered nox sessions."""
+    nox.registry._REGISTRY.clear()
+
+    def _iter_sessions() -> Iterator[str]:
+        options = nox._options.options.namespace()
+        manifest = nox.manifest.Manifest(nox.registry.get(), options)
+        for session in manifest:
+            yield session.name
+            yield from session.signatures
+
+    return _iter_sessions
 
 
 def test_kwargs() -> None:

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -58,6 +58,21 @@ def test_python(iter_sessions: IterSessions) -> None:
     assert set(iter_sessions()) == {"tests", "tests-3.8", "tests-3.9"}
 
 
+def test_parametrize(iter_sessions: IterSessions) -> None:
+    """It registers the session function for every parameter."""
+
+    @nox_poetry.session
+    @nox.parametrize("sphinx", ["2.4.4", "3.4.3"])
+    def tests(session: nox_poetry.Session, sphinx: str) -> None:
+        session.install(f"sphinx=={sphinx}")
+
+    assert set(iter_sessions()) == {
+        "tests",
+        "tests(sphinx='2.4.4')",
+        "tests(sphinx='3.4.3')",
+    }
+
+
 def test_wrapper(session: nox.Session) -> None:
     """It invokes the session function."""
     calls = []

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -48,6 +48,16 @@ def test_name(iter_sessions: IterSessions) -> None:
     assert "tests-renamed" in iter_sessions()
 
 
+def test_python(iter_sessions: IterSessions) -> None:
+    """It registers the session function for every python version."""
+
+    @nox_poetry.session(python=["3.8", "3.9"])
+    def tests(session: nox_poetry.Session) -> None:
+        pass
+
+    assert set(iter_sessions()) == {"tests", "tests-3.8", "tests-3.9"}
+
+
 def test_wrapper(session: nox.Session) -> None:
     """It invokes the session function."""
     calls = []


### PR DESCRIPTION
The session decorator introduced in 0.8 does not work with parametrized session functions, leading to errors similar to the following:

```python
nox > Session test(n=2) raised exception TypeError("wrapper() got an unexpected keyword argument 'n'")
```

This PR fixes the support for parametrized sessions by forwarding any additional arguments to the session function.