### PR TITLE
Do not set TMPDIR when exporting to requirements.txt

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -131,7 +131,6 @@ def tests(session: Session) -> None:
         session.install("dataclasses")
 
     try:
-        session.env.pop("TMPDIR", None)
         session.run("coverage", "run", "--parallel", "-m", "pytest", *session.posargs)
     finally:
         if session.interactive:

--- a/src/nox_poetry/sessions.py
+++ b/src/nox_poetry/sessions.py
@@ -160,7 +160,9 @@ class _PoetrySession:
         Returns:
             The path to the requirements file.
         """
-        tmpdir = Path(self.session.create_tmp())
+        tmpdir = Path(self.session.virtualenv.location) / "tmp"
+        tmpdir.mkdir(exist_ok=True)
+
         path = tmpdir / "requirements.txt"
         hashfile = tmpdir / f"{path.name}.hash"
 

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -8,12 +8,20 @@ from _pytest.monkeypatch import MonkeyPatch
 from nox.sessions import Session
 
 
+class FakeVirtualenv:
+    """Fake virtual environment."""
+
+    def __init__(self, path: Path) -> None:
+        """Initialize."""
+        self.location = str(path)
+
+
 class FakeSession:
     """Fake session."""
 
     def __init__(self, path: Path) -> None:
         """Initialize."""
-        self.path = path
+        self.virtualenv = FakeVirtualenv(path)
 
     def run(self, *args: str, **kargs: Any) -> str:
         """Run."""
@@ -23,11 +31,6 @@ class FakeSession:
 
     def install(self, *args: str, **kargs: Any) -> None:
         """Install."""
-        pass
-
-    def create_tmp(self, *args: str, **kargs: Any) -> str:
-        """Create temporary directory."""
-        return str(self.path)
 
 
 @pytest.fixture

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -114,7 +114,7 @@ def proxy(session: nox.Session) -> nox_poetry.Session:
 
 def test_session_getattr(proxy: nox_poetry.Session) -> None:
     """It delegates to the real session."""
-    assert proxy.create_tmp()
+    assert proxy.virtualenv.location
 
 
 def test_session_install(proxy: nox_poetry.Session) -> None:

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -114,7 +114,8 @@ def proxy(session: nox.Session) -> nox_poetry.Session:
 
 def test_session_getattr(proxy: nox_poetry.Session) -> None:
     """It delegates to the real session."""
-    assert proxy.virtualenv.location
+    # Fixed in https://github.com/theacodes/nox/pull/377
+    assert proxy.virtualenv.location  # type: ignore[attr-defined]
 
 
 def test_session_install(proxy: nox_poetry.Session) -> None:


### PR DESCRIPTION
Do not set or modify TMPDIR in Nox sessions. nox-poetry should not modify the environment of users. Fiddling with TMPDIR can also lead to issues with other tools, especially since it happened at unpredictable points in the build process.

Previously, nox-poetry set TMPDIR indirectly by invoking session.create_tmp from export_requirements. We continue to use `<venv>/tmp` but create it ourselves instead of using session.create_tmp.

Closes #249 