### PR TITLE
Use portable file URLs when installing the root package

### DIFF
--- a/src/nox_poetry/sessions.py
+++ b/src/nox_poetry/sessions.py
@@ -191,7 +191,7 @@ class _PoetrySession:
             The file URL for the distribution package.
         """
         wheel = Path("dist") / self.poetry.build(format=distribution_format)
-        url = f"file://{wheel.resolve().as_posix()}"
+        url = wheel.resolve().as_uri()
 
         if DistributionFormat(distribution_format) is DistributionFormat.SDIST:
             url += f"#egg={self.poetry.config.name}"


### PR DESCRIPTION
Use Path.as_uri() to construct package URLs in a robust and portable way. The
pathlib implementation deals with a variety of issues on POSIX and especially on
Windows that aren't taken care of using our current method.
