### PR TITLE
Convert exported requirements to constraints format

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -686,7 +686,7 @@ tox_to_nox = ["jinja2", "tox"]
 name = "packaging"
 version = "20.9"
 description = "Core utilities for Python packages"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
 
@@ -903,7 +903,7 @@ python-versions = "*"
 name = "pyparsing"
 version = "2.4.7"
 description = "Python parsing module"
-category = "dev"
+category = "main"
 optional = false
 python-versions = ">=2.6, !=3.0.*, !=3.1.*, !=3.2.*"
 
@@ -1369,7 +1369,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "872d04eb655eef4313348b96e496a32bea34ea30b5162473d1bbb2f8aac34e9a"
+content-hash = "a27d49cafec75f4ffedf6e65849afe46d390f194ba13ecec899a970783b9e50b"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ Changelog = "https://github.com/cjolowicz/nox-poetry/releases"
 python = "^3.6.1"
 nox = ">=2020.8.22"
 tomlkit = "^0.7.0"
+packaging = ">=20.9"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.2"

--- a/src/nox_poetry/poetry.py
+++ b/src/nox_poetry/poetry.py
@@ -61,22 +61,25 @@ class Poetry:
             self._config = Config(Path.cwd())
         return self._config
 
-    def export(self, path: Path) -> None:
+    def export(self) -> str:
         """Export the lock file to requirements format.
 
-        Args:
-            path: The destination path.
+        Returns:
+            The generated requirements as text.
         """
-        self.session.run_always(
+        output = self.session.run_always(
             "poetry",
             "export",
             "--format=requirements.txt",
-            f"--output={path}",
             "--dev",
             *[f"--extras={extra}" for extra in self.config.extras],
             "--without-hashes",
             external=True,
+            silent=True,
+            stderr=None,
         )
+        assert isinstance(output, str)  # noqa: S101
+        return output
 
     def build(self, *, format: str) -> str:
         """Build the package.

--- a/src/nox_poetry/sessions.py
+++ b/src/nox_poetry/sessions.py
@@ -170,7 +170,8 @@ class _PoetrySession:
         digest = hashlib.blake2b(lockdata).hexdigest()
 
         if not hashfile.is_file() or hashfile.read_text() != digest:
-            self.poetry.export(path)
+            requirements = self.poetry.export()
+            path.write_text(requirements)
             hashfile.write_text(digest)
 
         return path

--- a/src/nox_poetry/sessions.py
+++ b/src/nox_poetry/sessions.py
@@ -5,10 +5,13 @@ import re
 from pathlib import Path
 from typing import Any
 from typing import Iterable
+from typing import Iterator
 from typing import Optional
 from typing import Tuple
 
 import nox
+from packaging.requirements import InvalidRequirement
+from packaging.requirements import Requirement
 
 from nox_poetry.poetry import DistributionFormat
 from nox_poetry.poetry import Poetry
@@ -50,6 +53,39 @@ def _split_extras(arg: str) -> Tuple[str, Optional[str]]:
     if match:
         return match.group(1), match.group(2)
     return arg, None
+
+
+def to_constraint(requirement_string: str, line: int) -> Optional[str]:
+    """Convert requirement to constraint."""
+    if any(
+        requirement_string.startswith(prefix)
+        for prefix in ("-e ", "file://", "git+https://", "http://", "https://")
+    ):
+        return None
+
+    try:
+        requirement = Requirement(requirement_string)
+    except InvalidRequirement as error:
+        raise RuntimeError(f"line {line}: {requirement_string!r}: {error}")
+
+    if not (requirement.name and requirement.specifier):
+        return None
+
+    constraint = f"{requirement.name}{requirement.specifier}"
+    return f"{constraint}; {requirement.marker}" if requirement.marker else constraint
+
+
+def to_constraints(requirements: str) -> str:
+    """Convert requirements to constraints."""
+
+    def _to_constraints() -> Iterator[str]:
+        lines = requirements.strip().splitlines()
+        for line, requirement in enumerate(lines, start=1):
+            constraint = to_constraint(requirement, line)
+            if constraint is not None:
+                yield constraint
+
+    return "\n".join(_to_constraints())
 
 
 class _PoetrySession:
@@ -170,8 +206,8 @@ class _PoetrySession:
         digest = hashlib.blake2b(lockdata).hexdigest()
 
         if not hashfile.is_file() or hashfile.read_text() != digest:
-            requirements = self.poetry.export()
-            path.write_text(requirements)
+            constraints = to_constraints(self.poetry.export())
+            path.write_text(constraints)
             hashfile.write_text(digest)
 
         return path

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -66,15 +66,11 @@ class Project:
     @property
     def dependencies(self) -> List[Package]:
         """Return the package dependencies."""
-        table = self._get_config("dependencies")
+        data = self._read_toml("poetry.lock")
         dependencies: List[str] = [
-            package
-            for package, info in table.items()
-            if not (
-                package == "python"
-                or isinstance(info, dict)
-                and info.get("optional", None)
-            )
+            package["name"]
+            for package in data["package"]
+            if package["category"] == "main" and not package["optional"]
         ]
         return [self.get_dependency(package) for package in dependencies]
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,7 +1,6 @@
 """Fixtures for functional tests."""
 import inspect
 import os
-import re
 import subprocess  # noqa: S404
 import sys
 from dataclasses import dataclass
@@ -16,6 +15,7 @@ from typing import TYPE_CHECKING
 
 import pytest
 import tomlkit
+from packaging.utils import canonicalize_name
 
 
 if TYPE_CHECKING:
@@ -134,14 +134,6 @@ def run_nox_with_noxfile(
     _run_nox(project)
 
 
-_CANONICALIZE_PATTERN = re.compile(r"[-_.]+")
-
-
-def _canonicalize_name(name: str) -> str:
-    # From ``packaging.utils.canonicalize_name`` (PEP 503)
-    return _CANONICALIZE_PATTERN.sub("-", name).lower()
-
-
 def list_packages(project: Project, session: SessionFunction) -> List[Package]:
     """List the installed packages for a session in the given project."""
     bindir = "Scripts" if sys.platform == "win32" else "bin"
@@ -164,7 +156,7 @@ def list_packages(project: Project, session: SessionFunction) -> List[Package]:
                 # But use the known version for the local package.
                 return project.package
 
-        name = _canonicalize_name(name)
+        name = canonicalize_name(name)
         return Package(name, version)
 
     return [parse(line) for line in process.stdout.splitlines()]

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -145,28 +145,14 @@ def write_noxfile(project: Project) -> WriteNoxfile:
     return functools.partial(_write_noxfile, project)
 
 
-def _run_nox_with_noxfile(
+def run_nox_with_noxfile(
     project: Project,
     sessions: Iterable[SessionFunction],
     imports: Iterable[ModuleType],
 ) -> None:
+    """Write a noxfile and run Nox in the project."""
     _write_noxfile(project, sessions, imports)
     _run_nox(project)
-
-
-RunNoxWithNoxfile = Callable[
-    [
-        Iterable[SessionFunction],
-        Iterable[ModuleType],
-    ],
-    None,
-]
-
-
-@pytest.fixture
-def run_nox_with_noxfile(project: Project) -> RunNoxWithNoxfile:
-    """Write a noxfile and run Nox in the project."""
-    return functools.partial(_run_nox_with_noxfile, project)
 
 
 _CANONICALIZE_PATTERN = re.compile(r"[-_.]+")

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -52,6 +52,10 @@ class Project:
         data = self._read_toml("poetry.lock")
         for package in data["package"]:
             if package["name"] == name:
+                url = package.get("source", {}).get("url")
+                if url is not None:
+                    # Abuse Package.version to store the URL (for ``list_packages``).
+                    return Package(name, url)
                 return Package(name, package["version"])
         raise ValueError(f"{name}: package not found")
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -177,7 +177,8 @@ def _canonicalize_name(name: str) -> str:
     return _CANONICALIZE_PATTERN.sub("-", name).lower()
 
 
-def _list_packages(project: Project, session: SessionFunction) -> List[Package]:
+def list_packages(project: Project, session: SessionFunction) -> List[Package]:
+    """List the installed packages for a session in the given project."""
     bindir = "Scripts" if sys.platform == "win32" else "bin"
     pip = project.path / ".nox" / session.__name__ / bindir / "pip"
     process = subprocess.run(  # noqa: S603
@@ -197,12 +198,3 @@ def _list_packages(project: Project, session: SessionFunction) -> List[Package]:
         return Package(name, version)
 
     return [parse(line) for line in process.stdout.splitlines()]
-
-
-ListPackages = Callable[[SessionFunction], List[Package]]
-
-
-@pytest.fixture
-def list_packages(project: Project) -> ListPackages:
-    """Return a function that lists the installed packages for a session."""
-    return functools.partial(_list_packages, project)

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -152,10 +152,15 @@ def list_packages(project: Project, session: SessionFunction) -> List[Package]:
 
     def parse(line: str) -> Package:
         name, _, version = line.partition("==")
+        if not version and " @ " in line:
+            # Abuse Package.version to store the URL or path.
+            name, _, version = line.partition(" @ ")
+
+            if name == project.package.name:
+                # But use the known version for the local package.
+                return project.package
+
         name = _canonicalize_name(name)
-        if not version and name.startswith(f"{project.package.name} @ file://"):
-            # Local package is listed without version, but it does not matter.
-            return project.package
         return Package(name, version)
 
     return [parse(line) for line in process.stdout.splitlines()]

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -1,5 +1,4 @@
 """Fixtures for functional tests."""
-import functools
 import inspect
 import os
 import re
@@ -119,21 +118,6 @@ def _write_noxfile(
 
     path = project.path / "noxfile.py"
     path.write_text(text)
-
-
-WriteNoxfile = Callable[
-    [
-        Iterable[SessionFunction],
-        Iterable[ModuleType],
-    ],
-    None,
-]
-
-
-@pytest.fixture
-def write_noxfile(project: Project) -> WriteNoxfile:
-    """Write a noxfile with the given session functions."""
-    return functools.partial(_write_noxfile, project)
 
 
 def run_nox_with_noxfile(

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -105,15 +105,6 @@ def _run_nox(project: Project) -> CompletedProcess:
         raise RuntimeError(f"{error}\n{error.stderr}")
 
 
-RunNox = Callable[[], CompletedProcess]
-
-
-@pytest.fixture
-def run_nox(project: Project) -> RunNox:
-    """Invoke Nox in the project."""
-    return functools.partial(_run_nox, project)
-
-
 SessionFunction = Callable[..., Any]
 
 

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -2,14 +2,13 @@
 import nox.sessions
 from tests.functional.conftest import list_packages
 from tests.functional.conftest import Project
-from tests.functional.conftest import RunNoxWithNoxfile
+from tests.functional.conftest import run_nox_with_noxfile
 
 import nox_poetry.patch
 
 
 def test_install_local_using_patch(
     project: Project,
-    run_nox_with_noxfile: RunNoxWithNoxfile,
 ) -> None:
     """It installs the local package."""
 
@@ -18,7 +17,7 @@ def test_install_local_using_patch(
         """Install the local package."""
         session.install(".")
 
-    run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry.patch])
+    run_nox_with_noxfile(project, [test], [nox, nox.sessions, nox_poetry.patch])
 
     expected = [project.package, *project.dependencies]
     packages = list_packages(project, test)
@@ -28,7 +27,6 @@ def test_install_local_using_patch(
 
 def test_install_local_using_patch_with_extras(
     project: Project,
-    run_nox_with_noxfile: RunNoxWithNoxfile,
 ) -> None:
     """It installs the extra."""
 
@@ -37,7 +35,7 @@ def test_install_local_using_patch_with_extras(
         """Install the local package."""
         session.install(".[pygments]")
 
-    run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry.patch])
+    run_nox_with_noxfile(project, [test], [nox, nox.sessions, nox_poetry.patch])
 
     expected = [
         project.package,
@@ -51,7 +49,6 @@ def test_install_local_using_patch_with_extras(
 
 def test_install_local_wheel(
     project: Project,
-    run_nox_with_noxfile: RunNoxWithNoxfile,
 ) -> None:
     """It builds and installs a wheel from the local package."""
 
@@ -60,7 +57,7 @@ def test_install_local_wheel(
         """Install the local package."""
         nox_poetry.install(session, ".")
 
-    run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry])
+    run_nox_with_noxfile(project, [test], [nox, nox.sessions, nox_poetry])
 
     expected = [project.package, *project.dependencies]
     packages = list_packages(project, test)
@@ -70,7 +67,6 @@ def test_install_local_wheel(
 
 def test_install_local_wheel_with_extras(
     project: Project,
-    run_nox_with_noxfile: RunNoxWithNoxfile,
 ) -> None:
     """It installs the extra."""
 
@@ -79,7 +75,7 @@ def test_install_local_wheel_with_extras(
         """Install the local package."""
         nox_poetry.install(session, ".[pygments]")
 
-    run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry])
+    run_nox_with_noxfile(project, [test], [nox, nox.sessions, nox_poetry])
 
     expected = [
         project.package,
@@ -93,7 +89,6 @@ def test_install_local_wheel_with_extras(
 
 def test_installroot_wheel(
     project: Project,
-    run_nox_with_noxfile: RunNoxWithNoxfile,
 ) -> None:
     """It builds and installs a wheel from the local package."""
 
@@ -102,7 +97,7 @@ def test_installroot_wheel(
         """Install the local package."""
         nox_poetry.installroot(session, distribution_format=nox_poetry.WHEEL)
 
-    run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry])
+    run_nox_with_noxfile(project, [test], [nox, nox.sessions, nox_poetry])
 
     expected = [project.package, *project.dependencies]
     packages = list_packages(project, test)
@@ -112,7 +107,6 @@ def test_installroot_wheel(
 
 def test_installroot_wheel_with_extras(
     project: Project,
-    run_nox_with_noxfile: RunNoxWithNoxfile,
 ) -> None:
     """It installs the extra."""
 
@@ -123,7 +117,7 @@ def test_installroot_wheel_with_extras(
             session, distribution_format=nox_poetry.WHEEL, extras=["pygments"]
         )
 
-    run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry])
+    run_nox_with_noxfile(project, [test], [nox, nox.sessions, nox_poetry])
 
     expected = [
         project.package,
@@ -137,7 +131,6 @@ def test_installroot_wheel_with_extras(
 
 def test_installroot_sdist(
     project: Project,
-    run_nox_with_noxfile: RunNoxWithNoxfile,
 ) -> None:
     """It builds and installs an sdist from the local package."""
 
@@ -146,7 +139,7 @@ def test_installroot_sdist(
         """Install the local package."""
         nox_poetry.installroot(session, distribution_format=nox_poetry.SDIST)
 
-    run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry])
+    run_nox_with_noxfile(project, [test], [nox, nox.sessions, nox_poetry])
 
     expected = [project.package, *project.dependencies]
     packages = list_packages(project, test)
@@ -156,7 +149,6 @@ def test_installroot_sdist(
 
 def test_installroot_sdist_with_extras(
     project: Project,
-    run_nox_with_noxfile: RunNoxWithNoxfile,
 ) -> None:
     """It installs the extra."""
 
@@ -167,7 +159,7 @@ def test_installroot_sdist_with_extras(
             session, distribution_format=nox_poetry.SDIST, extras=["pygments"]
         )
 
-    run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry])
+    run_nox_with_noxfile(project, [test], [nox, nox.sessions, nox_poetry])
 
     expected = [
         project.package,
@@ -181,7 +173,6 @@ def test_installroot_sdist_with_extras(
 
 def test_install_dependency_using_patch(
     project: Project,
-    run_nox_with_noxfile: RunNoxWithNoxfile,
 ) -> None:
     """It installs the pinned dependency."""
 
@@ -190,7 +181,7 @@ def test_install_dependency_using_patch(
         """Install the dependency."""
         session.install("pyflakes")
 
-    run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry.patch])
+    run_nox_with_noxfile(project, [test], [nox, nox.sessions, nox_poetry.patch])
 
     expected = [project.get_dependency("pyflakes")]
     packages = list_packages(project, test)
@@ -200,7 +191,6 @@ def test_install_dependency_using_patch(
 
 def test_install_dependency_without_patch(
     project: Project,
-    run_nox_with_noxfile: RunNoxWithNoxfile,
 ) -> None:
     """It installs the pinned dependency."""
 
@@ -209,7 +199,7 @@ def test_install_dependency_without_patch(
         """Install the dependency."""
         nox_poetry.install(session, "pycodestyle")
 
-    run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry])
+    run_nox_with_noxfile(project, [test], [nox, nox.sessions, nox_poetry])
 
     expected = [project.get_dependency("pycodestyle")]
     packages = list_packages(project, test)
@@ -219,7 +209,6 @@ def test_install_dependency_without_patch(
 
 def test_install_local_wheel_and_dependency_using_patch(
     project: Project,
-    run_nox_with_noxfile: RunNoxWithNoxfile,
 ) -> None:
     """It installs the wheel with pinned dependencies."""
 
@@ -228,7 +217,7 @@ def test_install_local_wheel_and_dependency_using_patch(
         """Install the dependency."""
         session.install(".", "pyflakes")
 
-    run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry.patch])
+    run_nox_with_noxfile(project, [test], [nox, nox.sessions, nox_poetry.patch])
 
     expected = [
         project.package,
@@ -242,7 +231,6 @@ def test_install_local_wheel_and_dependency_using_patch(
 
 def test_install_local_wheel_and_dependency_without_patch(
     project: Project,
-    run_nox_with_noxfile: RunNoxWithNoxfile,
 ) -> None:
     """It installs the wheel with pinned dependencies."""
 
@@ -251,7 +239,7 @@ def test_install_local_wheel_and_dependency_without_patch(
         """Install the dependency."""
         nox_poetry.install(session, ".", "pycodestyle")
 
-    run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry])
+    run_nox_with_noxfile(project, [test], [nox, nox.sessions, nox_poetry])
 
     expected = [
         project.package,
@@ -265,7 +253,6 @@ def test_install_local_wheel_and_dependency_without_patch(
 
 def test_session_install_local(
     project: Project,
-    run_nox_with_noxfile: RunNoxWithNoxfile,
 ) -> None:
     """It installs the local package."""
 
@@ -274,7 +261,7 @@ def test_session_install_local(
         """Install the local package."""
         session.install(".")
 
-    run_nox_with_noxfile([test], [nox_poetry])
+    run_nox_with_noxfile(project, [test], [nox_poetry])
 
     expected = [project.package, *project.dependencies]
     packages = list_packages(project, test)
@@ -284,7 +271,6 @@ def test_session_install_local(
 
 def test_session_install_local_with_extras(
     project: Project,
-    run_nox_with_noxfile: RunNoxWithNoxfile,
 ) -> None:
     """It installs the extra."""
 
@@ -293,7 +279,7 @@ def test_session_install_local_with_extras(
         """Install the local package."""
         session.install(".[pygments]")
 
-    run_nox_with_noxfile([test], [nox_poetry])
+    run_nox_with_noxfile(project, [test], [nox_poetry])
 
     expected = [
         project.package,
@@ -307,7 +293,6 @@ def test_session_install_local_with_extras(
 
 def test_session_install_dependency(
     project: Project,
-    run_nox_with_noxfile: RunNoxWithNoxfile,
 ) -> None:
     """It installs the pinned dependency."""
 
@@ -316,7 +301,7 @@ def test_session_install_dependency(
         """Install the dependency."""
         session.install("pyflakes")
 
-    run_nox_with_noxfile([test], [nox_poetry])
+    run_nox_with_noxfile(project, [test], [nox_poetry])
 
     expected = [project.get_dependency("pyflakes")]
     packages = list_packages(project, test)
@@ -326,7 +311,6 @@ def test_session_install_dependency(
 
 def test_session_install_local_wheel_and_dependency(
     project: Project,
-    run_nox_with_noxfile: RunNoxWithNoxfile,
 ) -> None:
     """It installs the wheel with pinned dependencies."""
 
@@ -335,7 +319,7 @@ def test_session_install_local_wheel_and_dependency(
         """Install the dependency."""
         session.install(".", "pyflakes")
 
-    run_nox_with_noxfile([test], [nox_poetry])
+    run_nox_with_noxfile(project, [test], [nox_poetry])
 
     expected = [
         project.package,
@@ -349,7 +333,6 @@ def test_session_install_local_wheel_and_dependency(
 
 def test_session_parametrize(
     project: Project,
-    run_nox_with_noxfile: RunNoxWithNoxfile,
 ) -> None:
     """It forwards parameters to sessions."""
 
@@ -358,4 +341,4 @@ def test_session_parametrize(
     def test(session: nox_poetry.Session, n: int) -> None:
         """Do nothing."""
 
-    run_nox_with_noxfile([test], [nox, nox_poetry])
+    run_nox_with_noxfile(project, [test], [nox, nox_poetry])

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -7,9 +7,7 @@ from tests.functional.conftest import run_nox_with_noxfile
 import nox_poetry.patch
 
 
-def test_install_local_using_patch(
-    project: Project,
-) -> None:
+def test_install_local_using_patch(project: Project) -> None:
     """It installs the local package."""
 
     @nox.session
@@ -25,9 +23,7 @@ def test_install_local_using_patch(
     assert set(expected) == set(packages)
 
 
-def test_install_local_using_patch_with_extras(
-    project: Project,
-) -> None:
+def test_install_local_using_patch_with_extras(project: Project) -> None:
     """It installs the extra."""
 
     @nox.session
@@ -47,9 +43,7 @@ def test_install_local_using_patch_with_extras(
     assert set(expected) == set(packages)
 
 
-def test_install_local_wheel(
-    project: Project,
-) -> None:
+def test_install_local_wheel(project: Project) -> None:
     """It builds and installs a wheel from the local package."""
 
     @nox.session
@@ -65,9 +59,7 @@ def test_install_local_wheel(
     assert set(expected) == set(packages)
 
 
-def test_install_local_wheel_with_extras(
-    project: Project,
-) -> None:
+def test_install_local_wheel_with_extras(project: Project) -> None:
     """It installs the extra."""
 
     @nox.session
@@ -87,9 +79,7 @@ def test_install_local_wheel_with_extras(
     assert set(expected) == set(packages)
 
 
-def test_installroot_wheel(
-    project: Project,
-) -> None:
+def test_installroot_wheel(project: Project) -> None:
     """It builds and installs a wheel from the local package."""
 
     @nox.session
@@ -105,9 +95,7 @@ def test_installroot_wheel(
     assert set(expected) == set(packages)
 
 
-def test_installroot_wheel_with_extras(
-    project: Project,
-) -> None:
+def test_installroot_wheel_with_extras(project: Project) -> None:
     """It installs the extra."""
 
     @nox.session
@@ -129,9 +117,7 @@ def test_installroot_wheel_with_extras(
     assert set(expected) == set(packages)
 
 
-def test_installroot_sdist(
-    project: Project,
-) -> None:
+def test_installroot_sdist(project: Project) -> None:
     """It builds and installs an sdist from the local package."""
 
     @nox.session
@@ -147,9 +133,7 @@ def test_installroot_sdist(
     assert set(expected) == set(packages)
 
 
-def test_installroot_sdist_with_extras(
-    project: Project,
-) -> None:
+def test_installroot_sdist_with_extras(project: Project) -> None:
     """It installs the extra."""
 
     @nox.session
@@ -171,9 +155,7 @@ def test_installroot_sdist_with_extras(
     assert set(expected) == set(packages)
 
 
-def test_install_dependency_using_patch(
-    project: Project,
-) -> None:
+def test_install_dependency_using_patch(project: Project) -> None:
     """It installs the pinned dependency."""
 
     @nox.session
@@ -189,9 +171,7 @@ def test_install_dependency_using_patch(
     assert set(expected) == set(packages)
 
 
-def test_install_dependency_without_patch(
-    project: Project,
-) -> None:
+def test_install_dependency_without_patch(project: Project) -> None:
     """It installs the pinned dependency."""
 
     @nox.session
@@ -207,9 +187,7 @@ def test_install_dependency_without_patch(
     assert set(expected) == set(packages)
 
 
-def test_install_local_wheel_and_dependency_using_patch(
-    project: Project,
-) -> None:
+def test_install_local_wheel_and_dependency_using_patch(project: Project) -> None:
     """It installs the wheel with pinned dependencies."""
 
     @nox.session
@@ -229,9 +207,7 @@ def test_install_local_wheel_and_dependency_using_patch(
     assert set(expected) == set(packages)
 
 
-def test_install_local_wheel_and_dependency_without_patch(
-    project: Project,
-) -> None:
+def test_install_local_wheel_and_dependency_without_patch(project: Project) -> None:
     """It installs the wheel with pinned dependencies."""
 
     @nox.session
@@ -251,9 +227,7 @@ def test_install_local_wheel_and_dependency_without_patch(
     assert set(expected) == set(packages)
 
 
-def test_session_install_local(
-    project: Project,
-) -> None:
+def test_session_install_local(project: Project) -> None:
     """It installs the local package."""
 
     @nox_poetry.session
@@ -269,9 +243,7 @@ def test_session_install_local(
     assert set(expected) == set(packages)
 
 
-def test_session_install_local_with_extras(
-    project: Project,
-) -> None:
+def test_session_install_local_with_extras(project: Project) -> None:
     """It installs the extra."""
 
     @nox_poetry.session
@@ -291,9 +263,7 @@ def test_session_install_local_with_extras(
     assert set(expected) == set(packages)
 
 
-def test_session_install_dependency(
-    project: Project,
-) -> None:
+def test_session_install_dependency(project: Project) -> None:
     """It installs the pinned dependency."""
 
     @nox_poetry.session
@@ -309,9 +279,7 @@ def test_session_install_dependency(
     assert set(expected) == set(packages)
 
 
-def test_session_install_local_wheel_and_dependency(
-    project: Project,
-) -> None:
+def test_session_install_local_wheel_and_dependency(project: Project) -> None:
     """It installs the wheel with pinned dependencies."""
 
     @nox_poetry.session
@@ -331,9 +299,7 @@ def test_session_install_local_wheel_and_dependency(
     assert set(expected) == set(packages)
 
 
-def test_session_parametrize(
-    project: Project,
-) -> None:
+def test_session_parametrize(project: Project) -> None:
     """It forwards parameters to sessions."""
 
     @nox_poetry.session

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -1,6 +1,6 @@
 """Functional tests."""
 import nox.sessions
-from tests.functional.conftest import ListPackages
+from tests.functional.conftest import list_packages
 from tests.functional.conftest import Project
 from tests.functional.conftest import RunNoxWithNoxfile
 
@@ -10,7 +10,6 @@ import nox_poetry.patch
 def test_install_local_using_patch(
     project: Project,
     run_nox_with_noxfile: RunNoxWithNoxfile,
-    list_packages: ListPackages,
 ) -> None:
     """It installs the local package."""
 
@@ -22,7 +21,7 @@ def test_install_local_using_patch(
     run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry.patch])
 
     expected = [project.package, *project.dependencies]
-    packages = list_packages(test)
+    packages = list_packages(project, test)
 
     assert set(expected) == set(packages)
 
@@ -30,7 +29,6 @@ def test_install_local_using_patch(
 def test_install_local_using_patch_with_extras(
     project: Project,
     run_nox_with_noxfile: RunNoxWithNoxfile,
-    list_packages: ListPackages,
 ) -> None:
     """It installs the extra."""
 
@@ -46,7 +44,7 @@ def test_install_local_using_patch_with_extras(
         *project.dependencies,
         project.get_dependency("pygments"),
     ]
-    packages = list_packages(test)
+    packages = list_packages(project, test)
 
     assert set(expected) == set(packages)
 
@@ -54,7 +52,6 @@ def test_install_local_using_patch_with_extras(
 def test_install_local_wheel(
     project: Project,
     run_nox_with_noxfile: RunNoxWithNoxfile,
-    list_packages: ListPackages,
 ) -> None:
     """It builds and installs a wheel from the local package."""
 
@@ -66,7 +63,7 @@ def test_install_local_wheel(
     run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry])
 
     expected = [project.package, *project.dependencies]
-    packages = list_packages(test)
+    packages = list_packages(project, test)
 
     assert set(expected) == set(packages)
 
@@ -74,7 +71,6 @@ def test_install_local_wheel(
 def test_install_local_wheel_with_extras(
     project: Project,
     run_nox_with_noxfile: RunNoxWithNoxfile,
-    list_packages: ListPackages,
 ) -> None:
     """It installs the extra."""
 
@@ -90,7 +86,7 @@ def test_install_local_wheel_with_extras(
         *project.dependencies,
         project.get_dependency("pygments"),
     ]
-    packages = list_packages(test)
+    packages = list_packages(project, test)
 
     assert set(expected) == set(packages)
 
@@ -98,7 +94,6 @@ def test_install_local_wheel_with_extras(
 def test_installroot_wheel(
     project: Project,
     run_nox_with_noxfile: RunNoxWithNoxfile,
-    list_packages: ListPackages,
 ) -> None:
     """It builds and installs a wheel from the local package."""
 
@@ -110,7 +105,7 @@ def test_installroot_wheel(
     run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry])
 
     expected = [project.package, *project.dependencies]
-    packages = list_packages(test)
+    packages = list_packages(project, test)
 
     assert set(expected) == set(packages)
 
@@ -118,7 +113,6 @@ def test_installroot_wheel(
 def test_installroot_wheel_with_extras(
     project: Project,
     run_nox_with_noxfile: RunNoxWithNoxfile,
-    list_packages: ListPackages,
 ) -> None:
     """It installs the extra."""
 
@@ -136,7 +130,7 @@ def test_installroot_wheel_with_extras(
         *project.dependencies,
         project.get_dependency("pygments"),
     ]
-    packages = list_packages(test)
+    packages = list_packages(project, test)
 
     assert set(expected) == set(packages)
 
@@ -144,7 +138,6 @@ def test_installroot_wheel_with_extras(
 def test_installroot_sdist(
     project: Project,
     run_nox_with_noxfile: RunNoxWithNoxfile,
-    list_packages: ListPackages,
 ) -> None:
     """It builds and installs an sdist from the local package."""
 
@@ -156,7 +149,7 @@ def test_installroot_sdist(
     run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry])
 
     expected = [project.package, *project.dependencies]
-    packages = list_packages(test)
+    packages = list_packages(project, test)
 
     assert set(expected) == set(packages)
 
@@ -164,7 +157,6 @@ def test_installroot_sdist(
 def test_installroot_sdist_with_extras(
     project: Project,
     run_nox_with_noxfile: RunNoxWithNoxfile,
-    list_packages: ListPackages,
 ) -> None:
     """It installs the extra."""
 
@@ -182,7 +174,7 @@ def test_installroot_sdist_with_extras(
         *project.dependencies,
         project.get_dependency("pygments"),
     ]
-    packages = list_packages(test)
+    packages = list_packages(project, test)
 
     assert set(expected) == set(packages)
 
@@ -190,7 +182,6 @@ def test_installroot_sdist_with_extras(
 def test_install_dependency_using_patch(
     project: Project,
     run_nox_with_noxfile: RunNoxWithNoxfile,
-    list_packages: ListPackages,
 ) -> None:
     """It installs the pinned dependency."""
 
@@ -202,7 +193,7 @@ def test_install_dependency_using_patch(
     run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry.patch])
 
     expected = [project.get_dependency("pyflakes")]
-    packages = list_packages(test)
+    packages = list_packages(project, test)
 
     assert set(expected) == set(packages)
 
@@ -210,7 +201,6 @@ def test_install_dependency_using_patch(
 def test_install_dependency_without_patch(
     project: Project,
     run_nox_with_noxfile: RunNoxWithNoxfile,
-    list_packages: ListPackages,
 ) -> None:
     """It installs the pinned dependency."""
 
@@ -222,7 +212,7 @@ def test_install_dependency_without_patch(
     run_nox_with_noxfile([test], [nox, nox.sessions, nox_poetry])
 
     expected = [project.get_dependency("pycodestyle")]
-    packages = list_packages(test)
+    packages = list_packages(project, test)
 
     assert set(expected) == set(packages)
 
@@ -230,7 +220,6 @@ def test_install_dependency_without_patch(
 def test_install_local_wheel_and_dependency_using_patch(
     project: Project,
     run_nox_with_noxfile: RunNoxWithNoxfile,
-    list_packages: ListPackages,
 ) -> None:
     """It installs the wheel with pinned dependencies."""
 
@@ -246,7 +235,7 @@ def test_install_local_wheel_and_dependency_using_patch(
         *project.dependencies,
         project.get_dependency("pyflakes"),
     ]
-    packages = list_packages(test)
+    packages = list_packages(project, test)
 
     assert set(expected) == set(packages)
 
@@ -254,7 +243,6 @@ def test_install_local_wheel_and_dependency_using_patch(
 def test_install_local_wheel_and_dependency_without_patch(
     project: Project,
     run_nox_with_noxfile: RunNoxWithNoxfile,
-    list_packages: ListPackages,
 ) -> None:
     """It installs the wheel with pinned dependencies."""
 
@@ -270,7 +258,7 @@ def test_install_local_wheel_and_dependency_without_patch(
         *project.dependencies,
         project.get_dependency("pycodestyle"),
     ]
-    packages = list_packages(test)
+    packages = list_packages(project, test)
 
     assert set(expected) == set(packages)
 
@@ -278,7 +266,6 @@ def test_install_local_wheel_and_dependency_without_patch(
 def test_session_install_local(
     project: Project,
     run_nox_with_noxfile: RunNoxWithNoxfile,
-    list_packages: ListPackages,
 ) -> None:
     """It installs the local package."""
 
@@ -290,7 +277,7 @@ def test_session_install_local(
     run_nox_with_noxfile([test], [nox_poetry])
 
     expected = [project.package, *project.dependencies]
-    packages = list_packages(test)
+    packages = list_packages(project, test)
 
     assert set(expected) == set(packages)
 
@@ -298,7 +285,6 @@ def test_session_install_local(
 def test_session_install_local_with_extras(
     project: Project,
     run_nox_with_noxfile: RunNoxWithNoxfile,
-    list_packages: ListPackages,
 ) -> None:
     """It installs the extra."""
 
@@ -314,7 +300,7 @@ def test_session_install_local_with_extras(
         *project.dependencies,
         project.get_dependency("pygments"),
     ]
-    packages = list_packages(test)
+    packages = list_packages(project, test)
 
     assert set(expected) == set(packages)
 
@@ -322,7 +308,6 @@ def test_session_install_local_with_extras(
 def test_session_install_dependency(
     project: Project,
     run_nox_with_noxfile: RunNoxWithNoxfile,
-    list_packages: ListPackages,
 ) -> None:
     """It installs the pinned dependency."""
 
@@ -334,7 +319,7 @@ def test_session_install_dependency(
     run_nox_with_noxfile([test], [nox_poetry])
 
     expected = [project.get_dependency("pyflakes")]
-    packages = list_packages(test)
+    packages = list_packages(project, test)
 
     assert set(expected) == set(packages)
 
@@ -342,7 +327,6 @@ def test_session_install_dependency(
 def test_session_install_local_wheel_and_dependency(
     project: Project,
     run_nox_with_noxfile: RunNoxWithNoxfile,
-    list_packages: ListPackages,
 ) -> None:
     """It installs the wheel with pinned dependencies."""
 
@@ -358,7 +342,7 @@ def test_session_install_local_wheel_and_dependency(
         *project.dependencies,
         project.get_dependency("pyflakes"),
     ]
-    packages = list_packages(test)
+    packages = list_packages(project, test)
 
     assert set(expected) == set(packages)
 

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -1,4 +1,6 @@
 """Functional tests."""
+from pathlib import Path
+
 import nox.sessions
 from tests.functional.conftest import list_packages
 from tests.functional.conftest import Project
@@ -308,3 +310,20 @@ def test_session_parametrize(project: Project) -> None:
         """Do nothing."""
 
     run_nox_with_noxfile(project, [test], [nox, nox_poetry])
+
+
+def test_install_with_url_dependency(datadir: Path) -> None:
+    """It installs the package."""
+    project = Project(datadir / "url-dependency")
+
+    @nox_poetry.session
+    def test(session: nox_poetry.Session) -> None:
+        """Install the local package."""
+        session.install(".")
+
+    run_nox_with_noxfile(project, [test], [nox_poetry])
+
+    expected = [project.package, *project.dependencies]
+    packages = list_packages(project, test)
+
+    assert set(expected) == set(packages)

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -327,3 +327,20 @@ def test_install_with_url_dependency(datadir: Path) -> None:
     packages = list_packages(project, test)
 
     assert set(expected) == set(packages)
+
+
+def test_install_with_path_dependency(datadir: Path) -> None:
+    """It installs the package."""
+    project = Project(datadir / "path-dependency")
+
+    @nox_poetry.session
+    def test(session: nox_poetry.Session) -> None:
+        """Install the local package."""
+        session.install(".")
+
+    run_nox_with_noxfile(project, [test], [nox_poetry])
+
+    expected = [project.package, *project.dependencies]
+    packages = list_packages(project, test)
+
+    assert set(expected) == set(packages)

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -2,6 +2,7 @@
 from pathlib import Path
 
 import nox.sessions
+import pytest
 from tests.functional.conftest import list_packages
 from tests.functional.conftest import Project
 from tests.functional.conftest import run_nox_with_noxfile
@@ -329,6 +330,8 @@ def test_install_with_url_dependency(datadir: Path) -> None:
     assert set(expected) == set(packages)
 
 
+# https://github.com/python-poetry/poetry/issues/3468
+@pytest.mark.xfail(reason="Poetry exports path requirements in an invalid format.")
 def test_install_with_path_dependency(datadir: Path) -> None:
     """It installs the package."""
     project = Project(datadir / "path-dependency")

--- a/tests/functional/test_functional/example/poetry.lock
+++ b/tests/functional/test_functional/example/poetry.lock
@@ -1,57 +1,57 @@
 [[package]]
-name = "first"
-version = "2.0.0"
-description = "Return the first true value of an iterable."
 category = "main"
+description = "Return the first true value of an iterable."
+name = "first"
 optional = false
 python-versions = "*"
+version = "2.0.2"
 
 [[package]]
-name = "pycodestyle"
-version = "2.5.0"
+category = "dev"
 description = "Python style guide checker"
-category = "dev"
+name = "pycodestyle"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.6.0"
 
 [[package]]
-name = "pyflakes"
-version = "2.1.1"
+category = "dev"
 description = "passive checker of Python programs"
-category = "dev"
+name = "pyflakes"
 optional = false
 python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "2.2.0"
 
 [[package]]
-name = "pygments"
-version = "2.7.1"
-description = "Pygments is a syntax highlighting package written in Python."
 category = "main"
+description = "Pygments is a syntax highlighting package written in Python."
+name = "pygments"
 optional = true
 python-versions = ">=3.5"
+version = "2.8.1"
 
 [extras]
 pygments = ["Pygments"]
 
 [metadata]
-lock-version = "1.1"
-python-versions = "^3.6.1"
 content-hash = "65a484a1a7ee49c3993d8103bddeeef3c94fc4fb6c3f3805d58941333e49e82a"
+lock-version = "1.0"
+python-versions = "^3.6.1"
 
 [metadata.files]
 first = [
-    {file = "first-2.0.0-py2.py3-none-any.whl", hash = "sha256:7ce8c2d25d2f7f54ad6d8a725df71e7a35ae11052d41cbeafcd19f71661a1107"},
-    {file = "first-2.0.0.tar.gz", hash = "sha256:c5711941f8ba8b091e73713eb0b45ddab663c060de324973b4cdd2290a1524ec"},
+    {file = "first-2.0.2-py2.py3-none-any.whl", hash = "sha256:8d8e46e115ea8ac652c76123c0865e3ff18372aef6f03c22809ceefcea9dec86"},
+    {file = "first-2.0.2.tar.gz", hash = "sha256:ff285b08c55f8c97ce4ea7012743af2495c9f1291785f163722bd36f6af6d3bf"},
 ]
 pycodestyle = [
-    {file = "pycodestyle-2.5.0-py2.py3-none-any.whl", hash = "sha256:95a2219d12372f05704562a14ec30bc76b05a5b297b21a5dfe3f6fac3491ae56"},
-    {file = "pycodestyle-2.5.0.tar.gz", hash = "sha256:e40a936c9a450ad81df37f549d676d127b1b66000a6c500caa2b085bc0ca976c"},
+    {file = "pycodestyle-2.6.0-py2.py3-none-any.whl", hash = "sha256:2295e7b2f6b5bd100585ebcb1f616591b652db8a741695b3d8f5d28bdc934367"},
+    {file = "pycodestyle-2.6.0.tar.gz", hash = "sha256:c58a7d2815e0e8d7972bf1803331fb0152f867bd89adf8a01dfd55085434192e"},
 ]
 pyflakes = [
-    {file = "pyflakes-2.1.1-py2.py3-none-any.whl", hash = "sha256:17dbeb2e3f4d772725c777fabc446d5634d1038f234e77343108ce445ea69ce0"},
-    {file = "pyflakes-2.1.1.tar.gz", hash = "sha256:d976835886f8c5b31d47970ed689944a0262b5f3afa00a5a7b4dc81e5449f8a2"},
+    {file = "pyflakes-2.2.0-py2.py3-none-any.whl", hash = "sha256:0d94e0e05a19e57a99444b6ddcf9a6eb2e5c68d3ca1e98e90707af8152c90a92"},
+    {file = "pyflakes-2.2.0.tar.gz", hash = "sha256:35b2d75ee967ea93b55750aa9edbbf72813e06a66ba54438df2cfac9e3c27fc8"},
 ]
 pygments = [
-    {file = "Pygments-2.7.1-py3-none-any.whl", hash = "sha256:307543fe65c0947b126e83dd5a61bd8acbd84abec11f43caebaf5534cbc17998"},
-    {file = "Pygments-2.7.1.tar.gz", hash = "sha256:926c3f319eda178d1bd90851e4317e6d8cdb5e292a3386aac9bd75eca29cf9c7"},
+    {file = "Pygments-2.8.1-py3-none-any.whl", hash = "sha256:534ef71d539ae97d4c3a4cf7d6f110f214b0e687e92f9cb9d2a3b0d3101289c8"},
+    {file = "Pygments-2.8.1.tar.gz", hash = "sha256:2656e1a6edcdabf4275f9a3640db59fd5de107d88e8663c5d4e9a0fa62f77f94"},
 ]

--- a/tests/functional/test_functional/path-dependency/poetry.lock
+++ b/tests/functional/test_functional/path-dependency/poetry.lock
@@ -1,0 +1,39 @@
+[[package]]
+category = "main"
+description = ""
+develop = true
+name = "example"
+optional = false
+python-versions = "^3.6.1"
+version = "0.1.0"
+
+[package.dependencies]
+first = "^2.0.0"
+
+[package.extras]
+pygments = ["Pygments (^2.7.1)"]
+
+[package.source]
+reference = ""
+type = "directory"
+url = "../example"
+
+[[package]]
+category = "main"
+description = "Return the first true value of an iterable."
+name = "first"
+optional = false
+python-versions = "*"
+version = "2.0.2"
+
+[metadata]
+content-hash = "5b4bb67e14af611647b481be0b303a180d88713c270fd4f73f47e2f1321f7696"
+lock-version = "1.0"
+python-versions = "^3.6.1"
+
+[metadata.files]
+example = []
+first = [
+    {file = "first-2.0.2-py2.py3-none-any.whl", hash = "sha256:8d8e46e115ea8ac652c76123c0865e3ff18372aef6f03c22809ceefcea9dec86"},
+    {file = "first-2.0.2.tar.gz", hash = "sha256:ff285b08c55f8c97ce4ea7012743af2495c9f1291785f163722bd36f6af6d3bf"},
+]

--- a/tests/functional/test_functional/path-dependency/pyproject.toml
+++ b/tests/functional/test_functional/path-dependency/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "path-dependency"
+version = "0.1.0"
+description = ""
+authors = ["Your Name <your.name@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.6.1"
+example = {path = "../example"}
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/functional/test_functional/path-dependency/src/path_dependency/__init__.py
+++ b/tests/functional/test_functional/path-dependency/src/path_dependency/__init__.py
@@ -1,0 +1,1 @@
+"""Example package for path dependencies."""

--- a/tests/functional/test_functional/url-dependency/poetry.lock
+++ b/tests/functional/test_functional/url-dependency/poetry.lock
@@ -1,0 +1,19 @@
+[[package]]
+category = "main"
+description = ""
+name = "poyo"
+optional = false
+python-versions = ">=2.7, !=3.0.*, !=3.1.*, !=3.2.*, !=3.3.*"
+version = "0.5.0"
+
+[package.source]
+reference = ""
+type = "url"
+url = "https://github.com/hackebrot/poyo/archive/master.zip"
+[metadata]
+content-hash = "ff110fa8bd529837779d5f342f0367a2707ef9f31ece6f059ba47a616e5ebcb4"
+lock-version = "1.0"
+python-versions = "^3.6.1"
+
+[metadata.files]
+poyo = []

--- a/tests/functional/test_functional/url-dependency/pyproject.toml
+++ b/tests/functional/test_functional/url-dependency/pyproject.toml
@@ -1,0 +1,15 @@
+[tool.poetry]
+name = "url-dependency"
+version = "0.1.0"
+description = ""
+authors = ["Your Name <your.name@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.6.1"
+poyo = {url = "https://github.com/hackebrot/poyo/archive/master.zip"}
+
+[tool.poetry.dev-dependencies]
+
+[build-system]
+requires = ["poetry>=0.12"]
+build-backend = "poetry.masonry.api"

--- a/tests/functional/test_functional/url-dependency/src/url_dependency/__init__.py
+++ b/tests/functional/test_functional/url-dependency/src/url_dependency/__init__.py
@@ -1,0 +1,1 @@
+"""Example package for URL dependencies."""


### PR DESCRIPTION
This PR fixes installation errors due to the use of some forms of requirements as constraints that are no longer supported with pip's new dependency resolver:

- URL requirements
- Path requirements
- Requirements with extras
- Editable requirements

Constraints are now rewritten in the form `name==version[; markers]`, and skipped if either name or version are empty. 

This PR adds a dependency on the [packaging] library.

Fixes #141

[packaging]: https://packaging.pypa.io/