### PR TITLE
Do not skip pre-install commands when --install-only is passed

### DIFF
--- a/poetry.lock
+++ b/poetry.lock
@@ -1369,7 +1369,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.6.1"
-content-hash = "54b25cc8f98eb0ee1c90f1ef3173d158b885a3e8d9055094ecef7f84e6629136"
+content-hash = "872d04eb655eef4313348b96e496a32bea34ea30b5162473d1bbb2f8aac34e9a"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,7 +21,7 @@ Changelog = "https://github.com/cjolowicz/nox-poetry/releases"
 
 [tool.poetry.dependencies]
 python = "^3.6.1"
-nox = "^2020.5.24"
+nox = ">=2020.8.22"
 tomlkit = "^0.7.0"
 
 [tool.poetry.dev-dependencies]

--- a/src/nox_poetry/poetry.py
+++ b/src/nox_poetry/poetry.py
@@ -67,7 +67,7 @@ class Poetry:
         Args:
             path: The destination path.
         """
-        self.session.run(
+        self.session.run_always(
             "poetry",
             "export",
             "--format=requirements.txt",
@@ -102,7 +102,7 @@ class Poetry:
         if not isinstance(format, DistributionFormat):
             format = DistributionFormat(format)
 
-        output = self.session.run(
+        output = self.session.run_always(
             "poetry",
             "build",
             f"--format={format}",

--- a/src/nox_poetry/sessions.py
+++ b/src/nox_poetry/sessions.py
@@ -102,7 +102,7 @@ class _PoetrySession:
 
             args = tuple(rewrite(arg, extras) for arg, extras in args_extras)
 
-            self.session.run("pip", "uninstall", "--yes", package, silent=True)
+            self.session.run_always("pip", "uninstall", "--yes", package, silent=True)
 
         requirements = self.export_requirements()
         Session_install(self.session, f"--constraint={requirements}", *args, **kwargs)
@@ -133,7 +133,7 @@ class _PoetrySession:
         package = self.build_package(distribution_format=distribution_format)
         requirements = self.export_requirements()
 
-        self.session.run("pip", "uninstall", "--yes", package, silent=True)
+        self.session.run_always("pip", "uninstall", "--yes", package, silent=True)
 
         suffix = ",".join(extras)
         if suffix.strip():

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -15,7 +15,7 @@ class FakeSession:
         """Initialize."""
         self.path = path
 
-    def run(self, *args: str, **kargs: Any) -> str:
+    def run_always(self, *args: str, **kargs: Any) -> str:
         """Run."""
         path = Path("dist") / "example.whl"
         path.touch()


### PR DESCRIPTION
Use [session.run_always] to ensure the following commands are still run when `--install-only` is passed to Nox:

- Exporting the lock file to constraints (`poetry export`)
- Building the package (`poetry build`)
- Reinstalling the package (`pip uninstall`)

[session.run_always]: https://nox.thea.codes/en/stable/config.html#nox.sessions.Session.run_always

nox-poetry now requires Nox 2020.8.22 or later, because the `session.run_always` method is not available in earlier versions.

Also, this PR fixes the Nox version constraint. The `^2020.5.24` constraint implies `< 2021`, preventing installation of nox-poetry with any Nox release newer than 2020.