### PR TITLE
Ignore empty lines in requirements.txt

### DIFF
--- a/src/nox_poetry/sessions.py
+++ b/src/nox_poetry/sessions.py
@@ -55,15 +55,15 @@ def _split_extras(arg: str) -> Tuple[str, Optional[str]]:
     return arg, None
 
 
-def to_constraint(requirement_string: str, line: int) -> Optional[str]:
-    """Convert requirement to constraint."""
-    if (
-        any(
-            requirement_string.startswith(prefix)
+def to_constraint(requirement_string: str, line: int) -> Optional[str]:         
+    """Convert requirement to constraint."""                                    
+    if (                                                                        
+        any(                                                                    
+            requirement_string.startswith(prefix)                               
             for prefix in ("-", "file://", "git+https://", "http://", "https://")
-	) 
-        or requirement_string.strip() == ""  # ignore empty lines as well
-    ):
+        )                                                                       
+        or requirement_string.strip() == ""  # ignore empty lines as well       
+    ):                                                                          
         return None
 
     try:

--- a/src/nox_poetry/sessions.py
+++ b/src/nox_poetry/sessions.py
@@ -61,7 +61,7 @@ def to_constraint(requirement_string: str, line: int) -> Optional[str]:
         any(
             requirement_string.startswith(prefix)
             for prefix in ("-", "file://", "git+https://", "http://", "https://")
-		) 
+	) 
         or requirement_string.strip() == ""  # ignore empty lines as well
     ):
         return None

--- a/src/nox_poetry/sessions.py
+++ b/src/nox_poetry/sessions.py
@@ -62,8 +62,8 @@ def to_constraint(requirement_string: str, line: int) -> Optional[str]:
             requirement_string.startswith(prefix)
             for prefix in ("-", "file://", "git+https://", "http://", "https://")
         ) 
-        or requirement_string.strip() == "")
-    :  # ignore empty lines as well
+        or requirement_string.strip() == ""
+    ):  # ignore empty lines as well
         return None
 
     try:

--- a/src/nox_poetry/sessions.py
+++ b/src/nox_poetry/sessions.py
@@ -61,9 +61,9 @@ def to_constraint(requirement_string: str, line: int) -> Optional[str]:
         any(
             requirement_string.startswith(prefix)
             for prefix in ("-", "file://", "git+https://", "http://", "https://")
-        ) 
-        or requirement_string.strip() == ""
-    ):  # ignore empty lines as well
+		) 
+        or requirement_string.strip() == ""  # ignore empty lines as well
+    ):
         return None
 
     try:

--- a/src/nox_poetry/sessions.py
+++ b/src/nox_poetry/sessions.py
@@ -57,10 +57,13 @@ def _split_extras(arg: str) -> Tuple[str, Optional[str]]:
 
 def to_constraint(requirement_string: str, line: int) -> Optional[str]:
     """Convert requirement to constraint."""
-    if any(
-        requirement_string.startswith(prefix)
-        for prefix in ("-", "file://", "git+https://", "http://", "https://")
-    ) or requirement_string.strip() == "":  # ignore empty lines as well
+    if (
+        any(
+            requirement_string.startswith(prefix)
+            for prefix in ("-", "file://", "git+https://", "http://", "https://")
+        ) 
+        or requirement_string.strip() == "")
+    :  # ignore empty lines as well
         return None
 
     try:

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -154,8 +154,12 @@ def test_session_build_package(proxy: nox_poetry.Session) -> None:
         ),
         ("-e ../lib/foo", ""),
         (
-            "--extra-index-url https://example.com/pypi/simple",
-            "",
+            """
+            --extra-index-url https://example.com/pypi/simple
+            
+            boltons==20.2.1
+            """,
+            "boltons==20.2.1",
         ),
     ],
 )

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -156,7 +156,7 @@ def test_session_build_package(proxy: nox_poetry.Session) -> None:
         (
             """
             --extra-index-url https://example.com/pypi/simple
-            
+
             boltons==20.2.1
             """,
             "boltons==20.2.1",


### PR DESCRIPTION
The --extra-index-url flag also inserts a blank line into the requirements.txt file.

```
--extra-index-url https://gitlab.com/api/v4/projects/XXX/packages/pypi/simple

aiobotocore==1.2.2; python_version >= "3.7"
aiohttp==3.7.4.post0; python_version >= "3.7"
...
```

So we want to return `None` if we are processing a blank line.

Related to #314 