### PR TITLE
Fix error due to blank lines in exported requirements

### DIFF
--- a/src/nox_poetry/sessions.py
+++ b/src/nox_poetry/sessions.py
@@ -57,12 +57,9 @@ def _split_extras(arg: str) -> Tuple[str, Optional[str]]:
 
 def to_constraint(requirement_string: str, line: int) -> Optional[str]:
     """Convert requirement to constraint."""
-    if (
-        any(
-            requirement_string.startswith(prefix)
-            for prefix in ("-", "file://", "git+https://", "http://", "https://")
-        )
-        or requirement_string.strip() == ""  # ignore empty lines as well
+    if any(
+        requirement_string.startswith(prefix)
+        for prefix in ("-", "file://", "git+https://", "http://", "https://")
     ):
         return None
 
@@ -82,11 +79,12 @@ def to_constraints(requirements: str) -> str:
     """Convert requirements to constraints."""
 
     def _to_constraints() -> Iterator[str]:
-        lines = requirements.strip().splitlines()
+        lines = requirements.splitlines()
         for line, requirement in enumerate(lines, start=1):
-            constraint = to_constraint(requirement, line)
-            if constraint is not None:
-                yield constraint
+            if requirement.strip():
+                constraint = to_constraint(requirement, line)
+                if constraint is not None:
+                    yield constraint
 
     return "\n".join(_to_constraints())
 

--- a/src/nox_poetry/sessions.py
+++ b/src/nox_poetry/sessions.py
@@ -57,9 +57,12 @@ def _split_extras(arg: str) -> Tuple[str, Optional[str]]:
 
 def to_constraint(requirement_string: str, line: int) -> Optional[str]:
     """Convert requirement to constraint."""
-    if any(
-        requirement_string.startswith(prefix)
-        for prefix in ("-", "file://", "git+https://", "http://", "https://")
+    if (
+        any(
+            requirement_string.startswith(prefix)
+            for prefix in ("-", "file://", "git+https://", "http://", "https://")
+        )
+        or requirement_string.strip() == ""  # ignore empty lines as well
     ):
         return None
 

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -1,4 +1,5 @@
 """Unit tests for the sessions module."""
+from textwrap import dedent
 from typing import Callable
 from typing import Iterator
 
@@ -153,9 +154,16 @@ def test_session_build_package(proxy: nox_poetry.Session) -> None:
             'regex==2020.10.28; python_version == "3.5"',
         ),
         ("-e ../lib/foo", ""),
+        ("--extra-index-url https://example.com/pypi/simple", ""),
         (
-            "--extra-index-url https://example.com/pypi/simple",
-            "",
+            dedent(
+                """
+                --extra-index-url https://example.com/pypi/simple
+
+                boltons==20.2.1
+                """
+            ),
+            "boltons==20.2.1",
         ),
     ],
 )


### PR DESCRIPTION
When converting exported requirements to constraints format, blank lines were not accounted for, resulting in an error like below when invoking `session.install`. Blank lines are now ignored.

```python
RuntimeError: line 2: '': Parse error at "''": Expected W:(abcd...)
```

This builds on @matteosantama's work in #319 
Supercedes #319 
Related to #314 