### PR TITLE
Make poetry a main dependency

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,7 @@ python = "^3.6.1"
 nox = ">=2020.8.22"
 tomlkit = "^0.7.0"
 packaging = ">=20.9"
+poetry = "^1.1.5"
 
 [tool.poetry.dev-dependencies]
 pytest = "^6.2.2"
@@ -47,7 +48,6 @@ reorder-python-imports = "^2.4.0"
 pre-commit-hooks = "^3.4.0"
 furo = "^2021.3.20b30"
 Pygments = "^2.8.1"
-poetry = "^1.1.5"
 pytest-datadir = "^1.3.1"
 dataclasses = {version = "^0.8", python = "<3.7"}
 


### PR DESCRIPTION
Obviously, this package does not run if `poetry` is not installed. Should `poetry` be promoted from a dev-dependency to a full dependency?