### PR TITLE
Parametrize Python in Nox session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -115,8 +115,11 @@ def mypy(session: Session) -> None:
         session.run("mypy", f"--python-executable={sys.executable}", "noxfile.py")
 
 
-@session(python=python_versions)
-@nox.parametrize("poetry", ["1.0.10", None])
+@session
+@nox.parametrize(
+    "python,poetry",
+    [(python_versions[0], "1.0.10"), *((python, None) for python in python_versions)],
+)
 def tests(session: Session, poetry: Optional[str]) -> None:
     """Run the test suite."""
     session.install(".")
@@ -132,9 +135,6 @@ def tests(session: Session, poetry: Optional[str]) -> None:
         session.install("dataclasses")
 
     if poetry is not None:
-        if session.python != python_versions[0]:
-            session.skip()
-
         session.run_always(
             "python", "-m", "pip", "install", f"poetry=={poetry}", silent=True
         )

--- a/noxfile.py
+++ b/noxfile.py
@@ -13,6 +13,7 @@ from nox_poetry import session
 
 package = "nox_poetry"
 python_versions = ["3.9", "3.8", "3.7", "3.6"]
+nox.needs_version = ">= 2021.6.6"
 nox.options.sessions = (
     "pre-commit",
     "safety",


### PR DESCRIPTION
This PR simplifies and improves nox-poetry's own Nox test suite:

- When running tests against different Poetry and Python versions, use the Python parametrization feature added in Nox 2021.6.6 to select the desired version combinations.
- Explicitly require Nox 2021.6.6 as the minimum version for our test suite, using `nox.needs_version`.