### PR TITLE
Fix crash when exported requirements contain Poetry warnings

### DIFF
--- a/src/nox_poetry/poetry.py
+++ b/src/nox_poetry/poetry.py
@@ -1,4 +1,5 @@
 """Poetry interface."""
+import sys
 from enum import Enum
 from pathlib import Path
 from typing import Any
@@ -100,6 +101,7 @@ class Poetry:
         def _stripwarnings(lines: Iterable[str]) -> Iterator[str]:
             for line in lines:
                 if line.startswith("Warning:"):
+                    print(line, file=sys.stderr)
                     continue
                 yield line
 

--- a/src/nox_poetry/poetry.py
+++ b/src/nox_poetry/poetry.py
@@ -2,6 +2,8 @@
 from enum import Enum
 from pathlib import Path
 from typing import Any
+from typing import Iterable
+from typing import Iterator
 from typing import List
 from typing import Optional
 
@@ -94,7 +96,14 @@ class Poetry:
             )
 
         assert isinstance(output, str)  # noqa: S101
-        return output
+
+        def _stripwarnings(lines: Iterable[str]) -> Iterator[str]:
+            for line in lines:
+                if line.startswith("Warning:"):
+                    continue
+                yield line
+
+        return "".join(_stripwarnings(output.splitlines(keepends=True)))
 
     def build(self, *, format: str) -> str:
         """Build the package.

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -129,10 +129,10 @@ def run_nox_with_noxfile(
     sessions: Iterable[SessionFunction],
     imports: Iterable[ModuleType],
     *nox_args: str,
-) -> None:
+) -> CompletedProcess:
     """Write a noxfile and run Nox in the project."""
     _write_noxfile(project, sessions, imports)
-    _run_nox(project, *nox_args)
+    return _run_nox(project, *nox_args)
 
 
 def list_packages(project: Project, session: SessionFunction) -> List[Package]:

--- a/tests/functional/test_functional.py
+++ b/tests/functional/test_functional.py
@@ -393,3 +393,17 @@ def test_installroot_no_install(project: Project) -> None:
     packages = list_packages(project, test)
 
     assert set(expected) == set(packages)
+
+
+def test_poetry_warnings(datadir: Path) -> None:
+    """It writes warnings from Poetry to the console."""
+    project = Project(datadir / "outdated-lockfile")
+
+    @nox_poetry.session
+    def test(session: nox_poetry.Session) -> None:
+        """Install the local package."""
+        session.install(".")
+
+    process = run_nox_with_noxfile(project, [test], [nox_poetry])
+
+    assert "Warning:" in process.stderr

--- a/tests/functional/test_functional/outdated-lockfile/poetry.lock
+++ b/tests/functional/test_functional/outdated-lockfile/poetry.lock
@@ -1,0 +1,8 @@
+package = []
+
+[metadata]
+lock-version = "1.1"
+python-versions = "^3.6.1"
+content-hash = "0000000000000000000000000000000000000000000000000000000000000000"
+
+[metadata.files]

--- a/tests/functional/test_functional/outdated-lockfile/pyproject.toml
+++ b/tests/functional/test_functional/outdated-lockfile/pyproject.toml
@@ -1,0 +1,12 @@
+[tool.poetry]
+name = "outdated-lockfile"
+version = "0.1.0"
+description = ""
+authors = ["Your Name <your.name@example.com>"]
+
+[tool.poetry.dependencies]
+python = "^3.6.1"
+
+[build-system]
+requires = ["poetry-core>=1.0.0"]
+build-backend = "poetry.core.masonry.api"

--- a/tests/functional/test_functional/outdated-lockfile/src/outdated_lockfile/__init__.py
+++ b/tests/functional/test_functional/outdated-lockfile/src/outdated_lockfile/__init__.py
@@ -1,0 +1,1 @@
+"""Package with an outdated lockfile."""

--- a/tests/unit/test_poetry.py
+++ b/tests/unit/test_poetry.py
@@ -1,5 +1,13 @@
 """Unit tests for the poetry module."""
 from pathlib import Path
+from typing import Any
+from typing import Dict
+
+import nox._options
+import nox.command
+import nox.manifest
+import nox.sessions
+import pytest
 
 from nox_poetry import poetry
 
@@ -16,3 +24,40 @@ name = "África"
 
     config = poetry.Config(path.parent)
     assert config.name == "África"
+
+
+@pytest.fixture
+def session(monkeypatch: pytest.MonkeyPatch) -> nox.Session:
+    """Fixture for a Nox session."""
+    registry: Dict[str, Any] = {}
+    monkeypatch.setattr("nox.registry._REGISTRY", registry)
+
+    @nox.session(venv_backend="none")
+    def test(session: nox.Session) -> None:
+        """Example session."""
+
+    config = nox._options.options.namespace(posargs=[])
+    [runner] = nox.manifest.Manifest(registry, config)
+    runner._create_venv()
+
+    return nox.Session(runner)
+
+
+def test_export_with_warnings(
+    session: nox.Session, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """It removes warnings from the output."""
+    requirements = "first==2.0.2\n"
+    warning = (
+        "Warning: The lock file is not up to date with the latest changes in"
+        " pyproject.toml. You may be getting outdated dependencies. Run update"
+        " to update them.\n"
+    )
+
+    def _run(*args: Any, **kwargs: Any) -> str:
+        return warning + requirements
+
+    monkeypatch.setattr("nox.command.run", _run)
+
+    output = poetry.Poetry(session).export()
+    assert output == requirements


### PR DESCRIPTION
This PR changes the `Poetry.export` helper to detect and remove warnings in the command output. Any warnings found are written to standard error, so the user can see them.

Background: Poetry writes warnings to standard output when exporting the requirements. This results in a parse error from `packaging` when it attempts to parse the warning as a requirement. A common case is the warning about an outdated lock file.

Fixes #349 