### PR TITLE
📚 [README] Fix duplication definition of "Status"

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -7,9 +7,6 @@ nox-poetry
 
 |pre-commit| |Black|
 
-.. |Status| image:: https://badgen.net/badge/status/alpha/d8624d
-   :target: https://badgen.net/badge/status/alpha/d8624d
-   :alt: Project Status
 .. |PyPI| image:: https://img.shields.io/pypi/v/nox-poetry.svg
    :target: https://pypi.org/project/nox-poetry/
    :alt: PyPI


### PR DESCRIPTION
Fixes #480

This error was caught by twine in the PyPI GitHub Action:

```
  Checking dist/nox_poetry-0.8.7.dev1632502539-py3-none-any.whl: FAILED
    `long_description` has syntax errors in markup and would not be rendered on PyPI.
      line 16: Error: Duplicate substitution definition name: "Status".
```