### PR TITLE
➖ [poetry] Remove dataclasses from development dependencies

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -134,8 +134,6 @@ def tests(session: Session, poetry: Optional[str]) -> None:
         "pygments",
         "typing_extensions",
     )
-    if session.python == "3.6":
-        session.install("dataclasses")
 
     if poetry is not None:
         session.run_always(

--- a/poetry.lock
+++ b/poetry.lock
@@ -1395,7 +1395,7 @@ testing = ["pytest (>=4.6)", "pytest-checkdocs (>=1.2.3)", "pytest-flake8", "pyt
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "5aa6033b5af209f5f25aad77ffcbbb4bfd2529c347dcdc2f1182b73052bbd693"
+content-hash = "2ac90f1a5e1e936e0097f436ace2177156b7ddc9c3fef979c61789a8bb27537e"
 
 [metadata.files]
 alabaster = [

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -45,7 +45,6 @@ furo = "^2021.11.12"
 Pygments = "^2.10.0"
 poetry = "^1.1.11"
 pytest-datadir = "^1.3.1"
-dataclasses = {version = "^0.8", python = "<3.7"}
 typing-extensions = "^3.10.0"
 pyupgrade = "^2.29.0"
 


### PR DESCRIPTION
The dataclasses backport was required for Python 3.6 which we no longer support.
