### PR TITLE
👷 [readthedocs] Use Python 3.10 on Read the Docs

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -1,11 +1,12 @@
 version: 2
+build:
+  os: ubuntu-20.04
+  tools:
+    python: "3.10"
 sphinx:
   configuration: docs/conf.py
 formats: all
 python:
-  version: 3.9
   install:
     - requirements: docs/requirements.txt
     - path: .
-build:
-  image: testing


### PR DESCRIPTION
* 👷 [readthedocs] Switch to `build`-based YAML format

* 👷 [readthedocs] Use Python 3.10 on Read the Docs

Retrocookie-Original-Commit: cjolowicz/cookiecutter-hypermodern-python-instance@fc117bb
