### PR TITLE
👷 [github] Pin pip in virtual environments

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -44,6 +44,15 @@ jobs:
           pip install --constraint=.github/workflows/constraints.txt pip
           pip --version
 
+      - name: Upgrade pip in virtual environments
+        shell: python
+        run: |
+          import os
+          import pip
+
+          with open(os.environ["GITHUB_ENV"], mode="a") as io:
+              print(f"VIRTUALENV_PIP={pip.__version__}", file=io)
+
       - name: Install Poetry
         run: |
           pipx install --pip-args=--constraint=.github/workflows/constraints.txt poetry


### PR DESCRIPTION
* 👷 [github] Set `VIRTUALENV_PIP` to pin pip in virtual environments

* 👷 [github] Append to GITHUB_ENV in Python

This is horrible, but apparently Powershell's quote handling is too broken to do
this portably in the default shell. The previous version just ate the double
quotes.

Retrocookie-Original-Commit: cjolowicz/cookiecutter-hypermodern-python-instance@4463434
