### PR TITLE
👷 Replace reorder-python-imports with isort

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -33,12 +33,13 @@ repos:
         language: system
         types: [python]
         require_serial: true
-      - id: reorder-python-imports
-        name: Reorder python imports
-        entry: reorder-python-imports
+      - id: isort
+        name: isort
+        entry: isort
+        require_serial: true
         language: system
-        types: [python]
-        args: [--application-directories=src]
+        types_or: [cython, pyi, python]
+        args: ["--filter-files"]
       - id: trailing-whitespace
         name: Trim Trailing Whitespace
         entry: trailing-whitespace-fixer

--- a/noxfile.py
+++ b/noxfile.py
@@ -87,10 +87,10 @@ def precommit(session: Session) -> None:
         "flake8-bugbear",
         "flake8-docstrings",
         "flake8-rst-docstrings",
+        "isort",
         "pep8-naming",
         "pre-commit",
         "pre-commit-hooks",
-        "reorder-python-imports",
         "pyupgrade",
     )
     session.run("pre-commit", *args)

--- a/poetry.lock
+++ b/poetry.lock
@@ -21,17 +21,6 @@ importlib-metadata = {version = ">=0.23,<5", markers = "python_version == \"3.7\
 test = ["coverage", "flake8", "pexpect", "wheel"]
 
 [[package]]
-name = "aspy.refactor-imports"
-version = "3.0.1"
-description = "Utilities for refactoring imports in python-like syntax."
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-cached-property = {version = "*", markers = "python_version < \"3.8\""}
-
-[[package]]
 name = "atomicwrites"
 version = "1.4.0"
 description = "Atomic file writes."
@@ -137,14 +126,6 @@ requests = "*"
 [package.extras]
 filecache = ["lockfile (>=0.9)"]
 redis = ["redis (>=2.10.5)"]
-
-[[package]]
-name = "cached-property"
-version = "1.5.2"
-description = "A decorator for caching properties in classes."
-category = "dev"
-optional = false
-python-versions = "*"
 
 [[package]]
 name = "cachy"
@@ -512,6 +493,20 @@ description = "iniconfig: brain-dead simple config-ini parsing"
 category = "dev"
 optional = false
 python-versions = "*"
+
+[[package]]
+name = "isort"
+version = "5.10.1"
+description = "A Python utility / library to sort Python imports."
+category = "dev"
+optional = false
+python-versions = ">=3.6.1,<4.0"
+
+[package.extras]
+pipfile_deprecated_finder = ["pipreqs", "requirementslib"]
+requirements_deprecated_finder = ["pipreqs", "pip-api"]
+colors = ["colorama (>=0.4.3,<0.5.0)"]
+plugins = ["setuptools"]
 
 [[package]]
 name = "jeepney"
@@ -960,17 +955,6 @@ optional = false
 python-versions = ">=3.6"
 
 [[package]]
-name = "reorder-python-imports"
-version = "3.1.0"
-description = "Tool for reordering python imports"
-category = "dev"
-optional = false
-python-versions = ">=3.7"
-
-[package.dependencies]
-"aspy.refactor-imports" = ">=2.3.0"
-
-[[package]]
 name = "requests"
 version = "2.27.1"
 description = "Python HTTP for Humans."
@@ -1372,7 +1356,7 @@ testing = ["pytest (>=6)", "pytest-checkdocs (>=2.4)", "pytest-flake8", "pytest-
 [metadata]
 lock-version = "1.1"
 python-versions = "^3.7"
-content-hash = "f332fde190baf4dd6724f479cb197e84cde7a981188ccacddd7034e7dd0498f5"
+content-hash = "3b002b6c5b80558665301158525274c5bbfdf400ed5018958c67455f460c6f0f"
 
 [metadata.files]
 alabaster = [
@@ -1382,10 +1366,6 @@ alabaster = [
 argcomplete = [
     {file = "argcomplete-1.12.3-py2.py3-none-any.whl", hash = "sha256:291f0beca7fd49ce285d2f10e4c1c77e9460cf823eef2de54df0c0fec88b0d81"},
     {file = "argcomplete-1.12.3.tar.gz", hash = "sha256:2c7dbffd8c045ea534921e63b0be6fe65e88599990d8dc408ac8c542b72a5445"},
-]
-"aspy.refactor-imports" = [
-    {file = "aspy.refactor_imports-3.0.1-py2.py3-none-any.whl", hash = "sha256:bc257946fdf5abd9c60393cfb8d0b5d45a2b87d1ee0ede46584c8be5567bc669"},
-    {file = "aspy.refactor_imports-3.0.1.tar.gz", hash = "sha256:df497c3726ee2931b03d403e58a4590f7f4e60059b115cf5df0e07e70c7c73be"},
 ]
 atomicwrites = [
     {file = "atomicwrites-1.4.0-py2.py3-none-any.whl", hash = "sha256:6d1784dea7c0c8d4a5172b6c620f40b6e4cbfdf96d783691f2e1302a7b88e197"},
@@ -1435,10 +1415,6 @@ black = [
 cachecontrol = [
     {file = "CacheControl-0.12.11-py2.py3-none-any.whl", hash = "sha256:2c75d6a8938cb1933c75c50184549ad42728a27e9f6b92fd677c3151aa72555b"},
     {file = "CacheControl-0.12.11.tar.gz", hash = "sha256:a5b9fcc986b184db101aa280b42ecdcdfc524892596f606858e0b7a8b4d9e144"},
-]
-cached-property = [
-    {file = "cached-property-1.5.2.tar.gz", hash = "sha256:9fa5755838eecbb2d234c3aa390bd80fbd3ac6b6869109bfc1b499f7bd89a130"},
-    {file = "cached_property-1.5.2-py2.py3-none-any.whl", hash = "sha256:df4f613cf7ad9a588cc381aaf4a512d26265ecebd5eb9e1ba12f1319eb85a6a0"},
 ]
 cachy = [
     {file = "cachy-0.3.0-py2.py3-none-any.whl", hash = "sha256:338ca09c8860e76b275aff52374330efedc4d5a5e45dc1c5b539c1ead0786fe7"},
@@ -1623,6 +1599,10 @@ importlib-metadata = [
 iniconfig = [
     {file = "iniconfig-1.1.1-py2.py3-none-any.whl", hash = "sha256:011e24c64b7f47f6ebd835bb12a743f2fbe9a26d4cecaa7f53bc4f35ee9da8b3"},
     {file = "iniconfig-1.1.1.tar.gz", hash = "sha256:bc3af051d7d14b2ee5ef9969666def0cd1a000e121eaea580d4a313df4b37f32"},
+]
+isort = [
+    {file = "isort-5.10.1-py3-none-any.whl", hash = "sha256:6f62d78e2f89b4500b080fe3a81690850cd254227f27f75c3a0c491a1f351ba7"},
+    {file = "isort-5.10.1.tar.gz", hash = "sha256:e8443a5e7a020e9d7f97f1d7d9cd17c88bcb3bc7e218bf9cf5095fe550be2951"},
 ]
 jeepney = [
     {file = "jeepney-0.7.1-py3-none-any.whl", hash = "sha256:1b5a0ea5c0e7b166b2f5895b91a08c14de8915afda4407fb5022a195224958ac"},
@@ -1897,10 +1877,6 @@ pyyaml = [
     {file = "PyYAML-6.0-cp39-cp39-win32.whl", hash = "sha256:b5b9eccad747aabaaffbc6064800670f0c297e52c12754eb1d976c57e4f74dcb"},
     {file = "PyYAML-6.0-cp39-cp39-win_amd64.whl", hash = "sha256:b3d267842bf12586ba6c734f89d1f5b871df0273157918b0ccefa29deb05c21c"},
     {file = "PyYAML-6.0.tar.gz", hash = "sha256:68fb519c14306fec9720a2a5b45bc9f0c8d1b9c72adf45c37baedfcd949c35a2"},
-]
-reorder-python-imports = [
-    {file = "reorder_python_imports-3.1.0-py2.py3-none-any.whl", hash = "sha256:b0ad7c75d8dbf0941f005954764dc0c4673416a7cf15fe1710e89bdd2b965ef5"},
-    {file = "reorder_python_imports-3.1.0.tar.gz", hash = "sha256:6b7a810ee77a9be0e646033d034ce02457e32597c5f48e5faec1866ca9eb4957"},
 ]
 requests = [
     {file = "requests-2.27.1-py2.py3-none-any.whl", hash = "sha256:f22fa1e554c9ddfd16e6e41ac79759e17be9e492b3587efa038054674760e72d"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -39,7 +39,6 @@ flake8-docstrings = ">=1.6.0"
 flake8-rst-docstrings = ">=0.2.5"
 pep8-naming = ">=0.12.1"
 darglint = ">=1.8.1"
-reorder-python-imports = ">=3.1.0"
 pre-commit-hooks = ">=4.1.0"
 furo = ">=2022.1.2"
 Pygments = ">=2.11.2"
@@ -47,6 +46,7 @@ poetry = ">=1.1.12"
 pytest-datadir = ">=1.3.1"
 typing-extensions = ">=4.0.1"
 pyupgrade = ">=2.31.0"
+isort = ">=5.10.1"
 
 [tool.coverage.paths]
 source = ["src", "*/site-packages"]
@@ -58,6 +58,11 @@ source = ["nox_poetry"]
 [tool.coverage.report]
 show_missing = true
 fail_under = 100
+
+[tool.isort]
+profile = "black"
+force_single_line = true
+lines_after_imports = 2
 
 [tool.mypy]
 strict = true

--- a/src/nox_poetry/sessions.pyi
+++ b/src/nox_poetry/sessions.pyi
@@ -8,13 +8,14 @@ from typing import List
 from typing import Mapping
 from typing import NoReturn
 from typing import Optional
-from typing import overload
 from typing import Sequence
 from typing import TypeVar
 from typing import Union
+from typing import overload
 
 import nox.sessions
 import nox.virtualenv
+
 
 Python = Optional[Union[str, Sequence[str], bool]]
 

--- a/tests/functional/conftest.py
+++ b/tests/functional/conftest.py
@@ -7,11 +7,11 @@ from dataclasses import dataclass
 from pathlib import Path
 from textwrap import dedent
 from types import ModuleType
+from typing import TYPE_CHECKING
 from typing import Any
 from typing import Callable
 from typing import Iterable
 from typing import List
-from typing import TYPE_CHECKING
 
 import pytest
 import tomlkit.api  # https://github.com/sdispater/tomlkit/issues/128

--- a/tests/functional/test_install.py
+++ b/tests/functional/test_install.py
@@ -1,10 +1,10 @@
 """Functional tests for ``install``."""
 import nox.sessions
-from tests.functional.conftest import list_packages
-from tests.functional.conftest import Project
-from tests.functional.conftest import run_nox_with_noxfile
 
 import nox_poetry
+from tests.functional.conftest import Project
+from tests.functional.conftest import list_packages
+from tests.functional.conftest import run_nox_with_noxfile
 
 
 def test_local_wheel(project: Project) -> None:

--- a/tests/functional/test_installroot.py
+++ b/tests/functional/test_installroot.py
@@ -1,10 +1,10 @@
 """Functional tests for ``installroot``."""
 import nox.sessions
-from tests.functional.conftest import list_packages
-from tests.functional.conftest import Project
-from tests.functional.conftest import run_nox_with_noxfile
 
 import nox_poetry
+from tests.functional.conftest import Project
+from tests.functional.conftest import list_packages
+from tests.functional.conftest import run_nox_with_noxfile
 
 
 def test_wheel(project: Project) -> None:

--- a/tests/functional/test_patch.py
+++ b/tests/functional/test_patch.py
@@ -1,10 +1,10 @@
 """Functional tests using ``path``."""
 import nox.sessions
-from tests.functional.conftest import list_packages
-from tests.functional.conftest import Project
-from tests.functional.conftest import run_nox_with_noxfile
 
 import nox_poetry.patch
+from tests.functional.conftest import Project
+from tests.functional.conftest import list_packages
+from tests.functional.conftest import run_nox_with_noxfile
 
 
 def test_local(project: Project) -> None:

--- a/tests/functional/test_poetry.py
+++ b/tests/functional/test_poetry.py
@@ -1,9 +1,8 @@
 """Functional tests for ``session.poetry``."""
-from tests.functional.conftest import list_packages
-from tests.functional.conftest import Project
-from tests.functional.conftest import run_nox_with_noxfile
-
 import nox_poetry
+from tests.functional.conftest import Project
+from tests.functional.conftest import list_packages
+from tests.functional.conftest import run_nox_with_noxfile
 
 
 def test_passthrough_env(project: Project) -> None:

--- a/tests/functional/test_session.py
+++ b/tests/functional/test_session.py
@@ -3,11 +3,11 @@ from pathlib import Path
 
 import nox.sessions
 import pytest
-from tests.functional.conftest import list_packages
-from tests.functional.conftest import Project
-from tests.functional.conftest import run_nox_with_noxfile
 
 import nox_poetry.patch
+from tests.functional.conftest import Project
+from tests.functional.conftest import list_packages
+from tests.functional.conftest import run_nox_with_noxfile
 
 
 def test_local(project: Project) -> None:

--- a/tests/unit/conftest.py
+++ b/tests/unit/conftest.py
@@ -2,8 +2,9 @@
 import sys
 from pathlib import Path
 from typing import Any
-from typing import cast
 from typing import Optional
+from typing import cast
+
 
 if sys.version_info >= (3, 8):
     from typing import Protocol

--- a/tests/unit/test_sessions.py
+++ b/tests/unit/test_sessions.py
@@ -1,18 +1,18 @@
 """Unit tests for the sessions module."""
 from textwrap import dedent
 from typing import Callable
-from typing import cast
 from typing import Iterator
+from typing import cast
 
 import nox._options
 import nox.manifest
 import nox.registry
 import pytest
-from tests.unit.conftest import FakeSession
-from tests.unit.conftest import FakeSessionFactory
 
 import nox_poetry
 from nox_poetry.sessions import to_constraints  # type: ignore[attr-defined]
+from tests.unit.conftest import FakeSession
+from tests.unit.conftest import FakeSessionFactory
 
 
 IterSessions = Callable[[], Iterator[str]]


### PR DESCRIPTION
* ➕ [poetry] Add isort 5.10.1

* 🔧 [nox] Add isort to lint dependencies

* 🔧 [pre-commit] Replace reorder-python-imports hook by isort

* 🔧 [isort] Use black profile

* 🔧 [isort] Force single line per import

* 🔧 [isort] Force double blank line after imports

* 💄 [nox] Add double blank line after imports

* 🔧 [nox] Remove reorder-python-imports from lint dependencies

* ➖ [poetry] Remove reorder-python-imports

Retrocookie-Original-Commit: cjolowicz/cookiecutter-hypermodern-python-instance@f196e3c
