### PR TITLE
Use original copyright year in docs

### DIFF
--- a/.cookiecutter.json
+++ b/.cookiecutter.json
@@ -1,6 +1,7 @@
 {
   "_template": "https://github.com/cjolowicz/cookiecutter-hypermodern-python",
   "author": "Claudio Jolowicz",
+  "copyright_year": "2020",
   "development_status": "Development Status :: 3 - Alpha",
   "email": "mail@claudiojolowicz.com",
   "friendly_name": "nox-poetry",

--- a/LICENSE.rst
+++ b/LICENSE.rst
@@ -1,7 +1,7 @@
 MIT License
 ===========
 
-Copyright © 2020-2021 Claudio Jolowicz
+Copyright © 2020 Claudio Jolowicz
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,7 +1,7 @@
 """Sphinx configuration."""
 project = "nox-poetry"
 author = "Claudio Jolowicz"
-copyright = "2020, {author}"
+copyright = "2020, Claudio Jolowicz"
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -1,10 +1,7 @@
 """Sphinx configuration."""
-from datetime import datetime
-
-
 project = "nox-poetry"
 author = "Claudio Jolowicz"
-copyright = f"{datetime.now().year}, {author}"
+copyright = "2020, {author}"
 extensions = [
     "sphinx.ext.autodoc",
     "sphinx.ext.intersphinx",


### PR DESCRIPTION
- 👷 Replace reorder-python-imports with isort
- Add template variable for copyright year (#1101)
- Use author template variable in docs' copyright (#1110)
