### PR TITLE
Move darglint to its own manual pre-commit hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -21,6 +21,12 @@ repos:
         entry: check-yaml
         language: system
         types: [yaml]
+      - id: darglint
+        name: darglint
+        entry: darglint
+        language: system
+        types: [python]
+        stages: [manual]
       - id: end-of-file-fixer
         name: Fix End of Files
         entry: end-of-file-fixer
@@ -33,6 +39,7 @@ repos:
         language: system
         types: [python]
         require_serial: true
+        args: [--darglint-ignore-regex, .*]
       - id: isort
         name: isort
         entry: isort

--- a/noxfile.py
+++ b/noxfile.py
@@ -103,7 +103,12 @@ def activate_virtualenv_in_precommit_hooks(session: Session) -> None:
 @session(name="pre-commit", python=python_versions[0])
 def precommit(session: Session) -> None:
     """Lint using pre-commit."""
-    args = session.posargs or ["run", "--all-files", "--show-diff-on-failure"]
+    args = session.posargs or [
+        "run",
+        "--all-files",
+        "--hook-stage=manual",
+        "--show-diff-on-failure",
+    ]
     session.install(
         "black",
         "darglint",

--- a/src/nox_poetry/core.py
+++ b/src/nox_poetry/core.py
@@ -35,8 +35,10 @@ def export_requirements(session: nox.sessions.Session) -> Path:
     return Session(session).poetry.export_requirements()
 
 
-def build_package(session: nox.sessions.Session, *, distribution_format: str) -> str:
-    """Build a distribution archive for the package.  # noqa: DAR
+def build_package(
+    session: nox.sessions.Session, *, distribution_format: str
+) -> str:  # noqa: DAR
+    """Build a distribution archive for the package.
 
     .. deprecated:: 0.8
        Use :func:`session` instead.


### PR DESCRIPTION
* Move darglint to its own idependent manual hook

* Trigger manual pre-commit stage by default

Retrocookie-Original-Commit: cjolowicz/cookiecutter-hypermodern-python-instance@9a4e480
