### PR TITLE
feat: add support for tags in session decorator

### DIFF
--- a/src/nox_poetry/sessions.pyi
+++ b/src/nox_poetry/sessions.pyi
@@ -44,4 +44,5 @@ def session(
     name: Optional[str] = ...,
     venv_backend: Any = ...,
     venv_params: Any = ...,
+    tags: Sequence[str] = ...,
 ) -> SessionDecorator: ...


### PR DESCRIPTION
Adds typing for tags in session decorator as the original nox session has support for tags. Closes #1219 