### PR TITLE
Add reference to Poetry 2 `poetry-export-plugin` `requires-plugin`

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,6 +48,16 @@ use the following command to install this package into the same environment:
 $ pipx inject nox nox-poetry
 ```
 
+`nox-poetry` relies on functionality from
+[`poetry-export-plugin`](https://github.com/python-poetry/poetry-plugin-export), which
+is bundled by default in Poetry 1, but not in Poetry >= 2. In Poetry 2, define it
+as a required plugin in your `pyproject.toml`:
+
+```toml
+[tool.poetry.requires-plugins]
+poetry-plugin-export = ">=1.8"
+```
+
 ## Requirements
 
 - Python 3.8+


### PR DESCRIPTION
Closes #874 

- https://python-poetry.org/blog/announcing-poetry-2.0.0/#poetry-export-and-poetry-shell-only-available-via-plugins
- https://python-poetry.org/blog/announcing-poetry-2.0.0/#project-plugins-and-forcing-a-minimum-poetry-version
- https://python-poetry.org/docs/cli#export