### PR TITLE
Update release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -45,7 +45,7 @@ jobs:
             bash -o pipefail -c "poetry version | awk '{ print \$2 }'"
 
       - name: Bump version for developmental release
-        if: "! steps.check-version.outputs.tag"
+        if: ${{ !steps.check-version.outputs.tag }}
         run: |
           poetry version patch &&
           version=$(poetry version | awk '{ print $2 }') &&
@@ -59,16 +59,14 @@ jobs:
         if: steps.check-version.outputs.tag
         uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
-          user: __token__
           password: ${{ secrets.PYPI_TOKEN }}
 
       - name: Publish package on TestPyPI
-        if: "! steps.check-version.outputs.tag"
+        if: ${{ !steps.check-version.outputs.tag }}
         uses: pypa/gh-action-pypi-publish@v1.12.4
         with:
-          user: __token__
           password: ${{ secrets.TEST_PYPI_TOKEN }}
-          repository_url: https://test.pypi.org/legacy/
+          repository-url: https://test.pypi.org/legacy/
 
       - name: Publish the release notes
         uses: release-drafter/release-drafter@v6.1.0


### PR DESCRIPTION
- Remove `username: __token__` as it's the default
- Use a correct syntax for GH workflow conditionals
- `repository_url` is deprecated in favor of `repository-url`